### PR TITLE
Merge tutorial to main scene, add skip flag, fix menu

### DIFF
--- a/Assets/LeapPaint (v3)/Materials/Hands/Capsule Hand Gray R Ghostable.mat
+++ b/Assets/LeapPaint (v3)/Materials/Hands/Capsule Hand Gray R Ghostable.mat
@@ -72,5 +72,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.6397059, g: 0.6397059, b: 0.6397059, a: 0.98828727}
+    - _Color: {r: 0.6397059, g: 0.6397059, b: 0.6397059, a: 0.96653575}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/LeapPaint (v3)/Scenes/LeapPaint (v3).unity
+++ b/Assets/LeapPaint (v3)/Scenes/LeapPaint (v3).unity
@@ -114,6 +114,34 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &707346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 707347}
+  m_Layer: 0
+  m_Name: Palm Direction Detector L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &707347
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 707346}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1372450353}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5218888
 GameObject:
   m_ObjectHideFlags: 0
@@ -367,6 +395,152 @@ MonoBehaviour:
   _horizontalAlignment: 1
   _verticalAlignment: 0
   _color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!43 &24147754
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Ribbon Circle Mesh
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 1536
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 256
+    localAABB:
+      m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
+      m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
+  m_Skin: []
+  m_VertexData:
+    serializedVersion: 2
+    m_VertexCount: 256
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 6144
+    _typelessdata: d9cef73c6f12833900000000a681353fa881343f67393ebc45b6f33c6f128339000000003e8034bf1e83353f822e3dbcd9cef73c6f1283b900000000a681353fa88134bf233d3e3c45b6f33c6f1283b9000000003e8034bf1e8335bfbb2a3d3c5e9df63c6f128339c15042bb5d57343f9c81343f59fda5bdd889f23c6f128339871a3fbbf2eb33bf1383353f8d026c3d5e9df63c6f1283b9c15042bb87ec343f9c8134bf5c536dbdd889f23c6f1283b9871a3fbb9b5733bf148335bf0912a53de30bf33c6f1283393861c1bb6270313fa581343f2a4d19be7507ef3c6f128339f42ebebbfb9b31bf1e83353f8c42013ee30bf33c6f1283b93861c1bb4699323fa58134bfd2fa01be7507ef3c6f1283b9f42ebebbbf7430bf1e8335bfb973183e3023ed3c6f128339a6de0fbc02d42c3f9e81343fa2215ebec437e93c6f128339e07d0dbc39962dbf1683353fc745463e3023ed3c6f1283b9a6de0fbcc48d2e3f9c8134bf956047bec437e93c6f1283b9e07d0dbce9de2bbf188335bf9de65c3edaf1e43c6f128339fea93dbc7e8d263fa281343f476990be1829e13c6f12833972873abc71e427bf1983353f17b0843edaf1e43c6f1283b9fea93dbcded3283fa08134bf4f6d85be1829e13c6f1283b972873abc49a125bf198335bf759c8f3e108cda3c6f128339bba169bc64ac1e3f9d81343fa95db0be4eefd63c6f12833923c565bcc89420bf1083353f37f6a43e108cda3c6f1283b9bba169bcc579213f988134bf79e1a5be4eefd63c6f1283b923c565bc5dcb1dbf158335bf8c63af3e790bce3c6f128339bbac89bc1544153f9b81343f3d9fcebe9da3ca3c6f1283392d6687bc24b917bf1d83353f86a5c33e790bce3c6f1283b9bbac89bc8591183fa78134bf84bcc4be9da3ca3c6f1283b92d6687bc647014bf128335bf427acd3ee48ebf3c6f1283392d359dbcb06b0a3fac81343f5ee3eabe5464bc3c6f128339f79b9abc7a670dbf2183353f8d72e03ee48ebf3c6f1283b92d359dbc22310e3fa88134bfa0b2e1be5464bc3c6f1283b9f79b9abc65a709bf268335bf3a96e93e093aaf3c6f128339083aafbc567cfc3e9f81343f3b7202bf9554ac3c6f1283399454acbc3eb901bf1783353f3e16fb3e093aaf3c6f1283b9083aafbc3b72023f9f8134bf567cfcbe9554ac3c6f1283b99454acbc3d16fbbe178335bf3eb9013f2e359d3c6f128339e38ebfbca0b2e13ea981343f23310ebff89b9a3c6f1283395364bcbc3a96e9be2683353f64a7093f2e359d3c6f1283b9e38ebfbc5ee3ea3eac8134bfb06b0abff89b9a3c6f1283b95364bcbc8d72e0be218335bf7a670d3fbcac893c6f128339780bcebc80bcc43ea581343f859118bf2e66873c6f1283399ca3cabc3f7acdbe1283353f6470143fbcac893c6f1283b9780bcebc3b9fce3e9b8134bf144415bf2e66873c6f1283b99ca3cabc86a5c3be1d8335bf27b9173fbca1693c6f1283390f8cdabc78e1a53e9a81343fc67921bf24c5653c6f1283394defd6bc8963afbe1483353f5ecb1d3fbca1693c6f1283b90f8cdabca75db03e9c8134bf64ac1ebf24c5653c6f1283b94defd6bc36f6a4be108335bfc794203fffa93d3c6f128339d9f1e4bc506d853ea081343fddd328bf73873a3c6f1283391729e1bc769c8fbe1983353f49a1253fffa93d3c6f1283b9d9f1e4bc4869903ea18134bf7d8d26bf73873a3c6f1283b91729e1bc18b084be198335bf70e4273fa8de0f3c6f1283392f23edbc9760473e9c81343fc58d2ebfe27d0d3c6f128339c337e9bc9ee65cbe1883353fe6de2b3fa8de0f3c6f1283b92f23edbca2215e3e9e8134bf01d42cbfe27d0d3c6f1283b9c337e9bcc94546be158335bf39962d3f3c61c13b6f128339e20bf3bce6fa013ea581343f459932bff82ebe3b6f1283397407efbcc27318be1d83353fbe74303f3c61c13b6f1283b9e20bf3bc344d193ea58134bf627031bff82ebe3b6f1283b97407efbca04201be1e8335bffb9b313fca50423b6f1283395e9df6bc34536d3d9b81343f87ec34bf901a3f3b6f128339d889f2bc1e12a5bd1483353f9b57333fca50423b6f1283b95e9df6bc6cfda53d9c8134bf5c5734bf901a3f3b6f1283b9d889f2bc64026cbd138335bff2eb333fea4918316f128339d8cef7bc073a3ebca781343fa68135bf84c515316f12833944b6f3bc5d2b3dbc1e83353f3e80343fea4918316f1283b9d8cef7bc073a3e3ca88134bfa68135bf84c515316f1283b944b6f3bc5d2b3d3c1e8335bf3e80343fb75042bb6f1283395e9df6bc46fda5bd9c81343f5d5734bf7d1a3fbb6f128339d889f2bc40026c3d1283353ff3eb333fb75042bb6f1283b95e9df6bc0d536dbd9b8134bf88ec34bf7d1a3fbb6f1283b9d889f2bcf811a53d168335bf9c57333f3261c1bb6f128339e30bf3bc2b4d19bea581343f627031bfee2ebebb6f1283397507efbc8c42013e1e83353ffb9b313f3261c1bb6f1283b9e30bf3bcd3fa01bea68134bf459932bfee2ebebb6f1283b97507efbcb973183e1d8335bfbe74303fa3de0fbc6f1283393023edbca2215ebe9e81343f02d42cbfdd7d0dbc6f128339c437e9bcc745463e1683353f39962d3fa3de0fbc6f1283b93023edbc956047be9c8134bfc48d2ebfdd7d0dbc6f1283b9c437e9bc9de65c3e188335bfe9de2b3ffba93dbc6f128339daf1e4bc476990bea281343f7e8d26bf6f873abc6f1283391829e1bc17b0843e1983353f71e4273ffba93dbc6f1283b9daf1e4bc4f6d85bea08134bfded328bf6f873abc6f1283b91829e1bc759c8f3e198335bf49a1253fb8a169bc6f128339108cdabca75db0be9c81343f64ac1ebf20c565bc6f1283394eefd6bc36f6a43e1083353fc794203fb8a169bc6f1283b9108cdabc78e1a5be9a8134bfc67921bf20c565bc6f1283b94eefd6bc8b63af3e148335bf5ecb1d3fbaac89bc6f128339790bcebc3c9fcebe9b81343f154415bf2c6687bc6f1283399da3cabc85a5c33e1d83353f26b9173fbaac89bc6f1283b9790bcebc80bcc4bea68134bf859118bf2c6687bc6f1283b99da3cabc3f7acd3e128335bf6470143f2c359dbc6f128339e48ebfbc5be3eabeac81343fb36b0abff69b9abc6f1283395464bcbc8972e03e2283353f79670d3f2c359dbc6f1283b9e48ebfbc9db2e1bea98134bf23310ebff69b9abc6f1283b95464bcbc3696e93e258335bf67a7093f083aafbc6f128339093aafbc3b7202bfa181343f517cfcbe9454acbc6f1283399554acbc3e16fb3e1683353f40b9013f083aafbc6f1283b9093aafbc567cfcbe9c8134bf3e7202bf9454acbc6f1283b99554acbc3eb9013f1a8335bf3816fb3ee28ebfbc6f1283392e359dbc25310ebfa881343f9eb2e1be5264bcbc6f128339f89b9abc66a7093f2783353f3396e93ee28ebfbc6f1283b92e359dbcb36b0abfaf8134bf59e3eabe5264bcbc6f1283b9f89b9abc7b670d3f1f8335bf8a72e03e770bcebc6f128339bcac89bc859118bfa781343f84bcc4be9ba3cabc6f1283392e6687bc6470143f1283353f427acd3e770bcebc6f1283b9bcac89bc154415bf9b8134bf3d9fcebe9ba3cabc6f1283b92e6687bc24b9173f1d8335bf86a5c33e0e8cdabc6f128339bda169bcc57921bf9881343f79e1a5be4cefd6bc6f12833925c565bc5dcb1d3f1583353f8b63af3e0e8cdabc6f1283b9bda169bc64ac1ebf9d8134bfa95db0be4cefd6bc6f1283b925c565bcc794203f108335bf37f6a43ed8f1e4bc6f12833900aa3dbcded328bfa181343f516d85be1629e1bc6f12833974873abc4aa1253f1a83353f779c8f3ed8f1e4bc6f1283b900aa3dbc7d8d26bfa18134bf486990be1629e1bc6f1283b974873abc70e4273f198335bf18b0843e2e23edbc6f128339a9de0fbcc58d2ebf9c81343f976047bec237e9bc6f128339e37d0dbce7de2b3f1983353f9fe65c3e2e23edbc6f1283b9a9de0fbc01d42cbf9e8134bfa2215ebec237e9bc6f1283b9e37d0dbc38962d3f148335bfc745463ee10bf3bc6f1283393e61c1bb459932bfa681343fe7fa01be7307efbc6f128339fa2ebebbbe74303f1d83353fc373183ee10bf3bc6f1283b93e61c1bb627031bfa58134bf354d19be7307efbc6f1283b9fa2ebebbfa9b313f1e8335bfa042013e5d9df6bc6f128339cf5042bb88ec34bf9b81343f35536dbdd789f2bc6f128339951a3fbb9b57333f1583353f1f12a53d5d9df6bc6f1283b9cf5042bb5c5734bf9c8134bf6dfda5bdd789f2bc6f1283b9951a3fbbf3eb333f148335bf67026c3dd7cef7bc6f128339228071b1a68135bfa781343f073a3e3c43b6f3bc6f12833940826db13e80343f1f83353f5e2b3d3cd7cef7bc6f1283b9228071b1a68135bfa78134bf073a3ebc43b6f3bc6f1283b940826db13e80343f1f8335bf5e2b3dbc5d9df6bc6f128339b150423b5c5734bf9c81343f46fda53dd789f2bc6f128339771a3f3bf3eb333f1283353f40026cbd5d9df6bc6f1283b9b150423b88ec34bf9b8134bf0d536d3dd789f2bc6f1283b9771a3f3b9b57333f158335bff611a5bde20bf3bc6f1283392f61c13b637031bfa481343f2a4d193e7407efbc6f128339eb2ebe3bfb9b313f1e83353f8c4201bee20bf3bc6f1283b92f61c13b469932bfa68134bfd3fa013e7407efbc6f1283b9eb2ebe3bbf74303f1e8335bfb97318be2f23edbc6f128339a2de0f3c01d42cbf9e81343fa2215e3ec337e9bc6f128339dc7d0d3c39962d3f1583353fc74546be2f23edbc6f1283b9a2de0f3cc58d2ebf9b8134bf9560473ec337e9bc6f1283b9dc7d0d3ce7de2b3f198335bf9ee65cbed9f1e4bc6f128339f9a93d3c7d8d26bfa081343f4869903e1729e1bc6f1283396d873a3c70e4273f1983353f18b084bed9f1e4bc6f1283b9f9a93d3cded328bfa18134bf516d853e1729e1bc6f1283b96d873a3c4aa1253f1a8335bf779c8fbe0f8cdabc6f128339b6a1693c64ac1ebf9c81343fa75db03e4defd6bc6f1283391ec5653cc794203f1083353f36f6a4be0f8cdabc6f1283b9b6a1693cc57921bf998134bf77e1a53e4defd6bc6f1283b91ec5653c5ecb1d3f148335bf8b63afbe780bcebc6f128339b9ac893c154415bf9b81343f3c9fce3e9ca3cabc6f1283392b66873c27b9173f1e83353f86a5c3be780bcebc6f1283b9b9ac893c859118bfa68134bf80bcc43e9ca3cabc6f1283b92b66873c6470143f128335bf3f7acdbee38ebfbc6f1283392b359d3cb36b0abfac81343f5be3ea3e5364bcbc6f128339f59b9a3c79670d3f2283353f8972e0bee38ebfbc6f1283b92b359d3c23310ebfa98134bf9db2e13e5364bcbc6f1283b9f59b9a3c67a7093f258335bf3696e9be083aafbc6f128339073aaf3c507cfcbea081343f3a72023f9454acbc6f1283399354ac3c40b9013f1683353f3e16fbbe083aafbc6f1283b9073aaf3c3e7202bf9c8134bf567cfc3e9454acbc6f1283b99354ac3c3816fb3e1a8335bf3eb901bf2d359dbc6f128339e18ebf3c9eb2e1bea881343f25310e3ff79b9abc6f1283395164bc3c3296e93e2683353f65a709bf2d359dbc6f1283b9e18ebf3c57e3eabeae8134bfb26b0a3ff79b9abc6f1283b95164bc3c8a72e03e1f8335bf7b670dbfbbac89bc6f128339760bce3c84bcc4bea781343f8591183f2d6687bc6f1283399aa3ca3c427acd3e1283353f647014bfbbac89bc6f1283b9760bce3c3d9fcebe9b8134bf1544153f2d6687bc6f1283b99aa3ca3c86a5c33e1d8335bf24b917bfbba169bc6f1283390d8cda3c79e1a5be9881343fc579213f23c565bc6f1283394befd63c8b63af3e1583353f5dcb1dbfbba169bc6f1283b90d8cda3ca95db0be9d8134bf64ac1e3f23c565bc6f1283b94befd63c37f6a43e108335bfc79420bffea93dbc6f128339d7f1e43c506d85bea081343fddd3283f72873abc6f1283391529e13c769c8f3e1983353f49a125bffea93dbc6f1283b9d7f1e43c486990bea18134bf7d8d263f72873abc6f1283b91529e13c18b0843e198335bf70e427bfa7de0fbc6f1283392d23ed3c976047be9c81343fc58d2e3fe17d0dbc6f128339c137e93c9ee65c3e1883353fe6de2bbfa7de0fbc6f1283b92d23ed3ca2215ebe9e8134bf01d42c3fe17d0dbc6f1283b9c137e93cc945463e158335bf39962dbf3a61c1bb6f128339e00bf33ce7fa01bea681343f4599323ff62ebebb6f1283397207ef3cc373183e1d83353fbe7430bf3a61c1bb6f1283b9e00bf33c354d19bea58134bf6270313ff62ebebb6f1283b97207ef3ca042013e1e8335bffa9b31bfc85042bb6f1283395c9df63c35536dbd9b81343f87ec343f8e1a3fbb6f128339d689f23c2012a53d1583353f9b5733bfc85042bb6f1283b95c9df63c6efda5bd9c8134bf5c57343f8e1a3fbb6f1283b9d689f23c67026c3d148335bff2eb33bf56c011b16f128339d6cef73c083a3e3ca681343fa681353f9a570fb16f12833942b6f33c5e2b3d3c1e83353f3e8034bf56c011b16f1283b9d6cef73c083a3ebca68134bfa681353f9a570fb16f1283b942b6f33c5e2b3dbc1e8335bf3e8034bfb650423b6f1283395c9df63c48fda53d9d81343f5d57343f7c1a3f3b6f128339d689f23c42026cbd1483353ff3eb33bfb650423b6f1283b95c9df63c0f536d3d9b8134bf88ec343f7c1a3f3b6f1283b9d689f23cf811a5bd158335bf9b5733bf3161c13b6f128339e10bf33c2a4d193ea481343f6370313fed2ebe3b6f1283397307ef3c8c4201be1e83353ffb9b31bf3161c13b6f1283b9e10bf33cd3fa013ea68134bf4699323fed2ebe3b6f1283b97307ef3cb97318be1d8335bfbf7430bfa3de0f3c6f1283392e23ed3ca2215e3e9e81343f01d42c3fdd7d0d3c6f128339c237e93cc74546be1583353f39962dbfa3de0f3c6f1283b92e23ed3c9560473e9b8134bfc58d2e3fdd7d0d3c6f1283b9c237e93c9ee65cbe198335bfe7de2bbffaa93d3c6f128339d8f1e43c4869903ea081343f7d8d263f6e873a3c6f1283391629e13c18b084be1983353f70e427bffaa93d3c6f1283b9d8f1e43c506d853ea08134bfddd3283f6e873a3c6f1283b91629e13c769c8fbe198335bf49a125bfb7a1693c6f1283390e8cda3ca95db03e9d81343f64ac1e3f1fc5653c6f1283394cefd63c37f6a4be1083353fc89420bfb7a1693c6f1283b90e8cda3c79e1a53e988134bfc579213f1fc5653c6f1283b94cefd63c8c63afbe158335bf5dcb1dbfb9ac893c6f128339770bce3c3d9fce3e9b81343f1544153f2b66873c6f1283399ba3ca3c86a5c3be1d83353f24b917bfb9ac893c6f1283b9770bce3c84bcc43ea78134bf8591183f2b66873c6f1283b99ba3ca3c427acdbe128335bf647014bf2b359d3c6f128339e28ebf3c54e3ea3eac81343fb56b0a3ff59b9a3c6f1283395264bc3c8872e0be2183353f7c670dbf2b359d3c6f1283b9e28ebf3c9ab2e13ea88134bf24310e3ff59b9a3c6f1283b95264bc3c2f96e9be268335bf69a709bf073aaf3c6f128339083aaf3c3e72023f9f81343f517cfc3e9354ac3c6f1283399454ac3c3916fbbe1983353f40b901bf073aaf3c6f1283b9083aaf3c517cfc3e9f8134bf3e72023f9354ac3c6f1283b99454ac3c40b901bf178335bf3816fbbee18ebf3c6f1283392c359d3c24310e3fa881343f99b2e13e5164bc3c6f128339f69b9a3c68a709bf2583353f2f96e9bee18ebf3c6f1283b92c359d3cb56b0a3fac8134bf54e3ea3e5164bc3c6f1283b9f69b9a3c7b670dbf218335bf8772e0be760bce3c6f128339baac893c8591183fa781343f84bcc43e9aa3ca3c6f1283392c66873c647014bf1283353f427acdbe760bce3c6f1283b9baac893c1544153f9b8134bf3d9fce3e9aa3ca3c6f1283b92c66873c24b917bf1d8335bf86a5c3be0d8cda3c6f128339b9a1693cc579213f9881343f79e1a53e4befd63c6f12833921c5653c5dcb1dbf1583353f8b63afbe0d8cda3c6f1283b9b9a1693c64ac1e3f9d8134bfa95db03e4befd63c6f1283b921c5653cc79420bf108335bf37f6a4bed7f1e43c6f128339fca93d3cded3283fa181343f516d853e1529e13c6f12833970873a3c4aa125bf1a83353f779c8fbed7f1e43c6f1283b9fca93d3c7d8d263fa18134bf4869903e1529e13c6f1283b970873a3c70e427bf198335bf18b084be2d23ed3c6f128339a5de0f3cc58d2e3f9c81343f9760473ec137e93c6f128339df7d0d3ce7de2bbf1983353f9fe65cbe2d23ed3c6f1283b9a5de0f3c01d42c3f9e8134bfa2215e3ec137e93c6f1283b9df7d0d3c38962dbf148335bfc74546bee00bf33c6f1283393661c13b4599323fa681343fe7fa013e7207ef3c6f128339f22ebe3bbe7430bf1d83353fc37318bee00bf33c6f1283b93661c13b6270313fa58134bf354d193e7207ef3c6f1283b9f22ebe3bfa9b31bf1e8335bfa04201be5c9df63c6f128339c050423b87ec343f9b81343f25546d3dd689f23c6f128339861a3f3b9a5733bf1483353f5a12a5bd5c9df63c6f1283b9c050423b5b57343f9c8134bfa9fda53dd689f23c6f1283b9861a3f3bf1eb33bf138335bf57036cbd
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
+    m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &27373161
 GameObject:
   m_ObjectHideFlags: 0
@@ -396,6 +570,38 @@ Transform:
   - {fileID: 1554716640}
   m_Father: {fileID: 901929145}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &30071808
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1254770691337346, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 30071809}
+  m_Layer: 0
+  m_Name: Color Swatch (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &30071809
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4280385014262436, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 30071808}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -1.2815094, y: 1.11, z: -0.64}
+  m_LocalScale: {x: 0.38721025, y: 0.38720945, z: 0.38720974}
+  m_Children:
+  - {fileID: 2094797849}
+  - {fileID: 1258465590}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &32826691
 Prefab:
@@ -467,6 +673,169 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 32826691}
+--- !u!1 &45922385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000013586280286, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 45922386}
+  - component: {fileID: 45922387}
+  m_Layer: 0
+  m_Name: Index
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &45922386
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000010959412872, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 45922385}
+  m_LocalRotation: {x: 0.8101432, y: -0.049420875, z: -0.19850695, w: -0.54938215}
+  m_LocalPosition: {x: -0.2669854, y: 1.5602217, z: 1.209359}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1994642041}
+  - {fileID: 1638628141}
+  - {fileID: 427834432}
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &45922387
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 45922385}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 243000011195632352, guid: 43de2443e9a4ff54e842fdf9d3168906,
+    type: 2}
+  m_audioClip: {fileID: 8300000, guid: 6f5a650c3de44044f98886081b52cb38, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 1
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+--- !u!1 &47246600
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 47246601}
+  m_Layer: 0
+  m_Name: Crappy Paintbrush
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &47246601
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 47246600}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.2, y: 1.1999998, z: 1.1999998}
+  m_Children:
+  - {fileID: 166893242}
+  - {fileID: 358618571}
+  - {fileID: 1354981793}
+  - {fileID: 305345373}
+  - {fileID: 955555649}
+  m_Father: {fileID: 206834524}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &51094817
 Prefab:
   m_ObjectHideFlags: 0
@@ -696,6 +1065,39 @@ Transform:
   m_Father: {fileID: 931763938}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -0.41300002, y: 1.182, z: 11.38}
+--- !u!1 &63207536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1577105535943408, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 63207537}
+  m_Layer: 0
+  m_Name: Color Palette Emergeable Parent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &63207537
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4864969470243794, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 63207536}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.00999999, y: 0.00999999, z: 0.00999999}
+  m_Children:
+  - {fileID: 446111048}
+  - {fileID: 2058638790}
+  - {fileID: 1282821179}
+  m_Father: {fileID: 2010003633}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &64935059
 GameObject:
   m_ObjectHideFlags: 0
@@ -730,6 +1132,38 @@ Transform:
   - {fileID: 466497090}
   m_Father: {fileID: 215092961}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &66919110
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1979171123199606, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 66919111}
+  m_Layer: 0
+  m_Name: Color Swatch (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &66919111
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4776862213735264, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 66919110}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 1.2446795, y: 1.11, z: -0.64}
+  m_LocalScale: {x: 0.38721025, y: 0.38720945, z: 0.38720974}
+  m_Children:
+  - {fileID: 530424314}
+  - {fileID: 1099494397}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &69701571
 GameObject:
@@ -919,6 +1353,81 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 72001963}
+--- !u!1 &72011314
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 72011315}
+  - component: {fileID: 72011317}
+  - component: {fileID: 72011316}
+  m_Layer: 0
+  m_Name: Give thumbs up to continue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &72011315
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72011314}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &72011316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72011314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 715153d525c322e47890cc24adb976b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1930824380}
+  transitionState: {fileID: 222778846}
+  withinAngle: 70
+  forDuration: 1
+--- !u!114 &72011317
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 72011314}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: SetText
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: Give me the thumbs up when you are ready to move on!
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1 &75253544
 GameObject:
   m_ObjectHideFlags: 0
@@ -1015,7 +1524,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 573826044}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &82778788
 GameObject:
@@ -1331,6 +1840,240 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 82859834}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &85683916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 85683917}
+  - component: {fileID: 85683919}
+  - component: {fileID: 85683918}
+  m_Layer: 0
+  m_Name: Button Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &85683917
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 85683916}
+  m_LocalRotation: {x: -0.0000000021199835, y: -0.70698947, z: 0.7072241, w: 0.0000000024046911}
+  m_LocalPosition: {x: 0, y: 0.4, z: 0}
+  m_LocalScale: {x: 0.1014021, y: 0.10140213, z: 0.10140213}
+  m_Children: []
+  m_Father: {fileID: 159747818}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 89.981, y: 0, z: 180}
+--- !u!102 &85683918
+TextMesh:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 85683916}
+  m_Text: 'Coming
+
+    soon!'
+  m_OffsetZ: 0
+  m_CharacterSize: 1
+  m_LineSpacing: 1
+  m_Anchor: 4
+  m_Alignment: 1
+  m_TabSize: 4
+  m_FontSize: 47
+  m_FontStyle: 0
+  m_RichText: 1
+  m_Font: {fileID: 12800000, guid: cd2b86fdeb787f84698ee40d32de9350, type: 3}
+  m_Color:
+    serializedVersion: 2
+    rgba: 4287072135
+--- !u!23 &85683919
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 85683916}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 89e1f0dde257b3c45a5f0b5574299f85, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &91909875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1916344639844562, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 91909876}
+  - component: {fileID: 91909878}
+  - component: {fileID: 91909877}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &91909876
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4424272460395580, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 91909875}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.10786719, y: 0.44517514, z: 0.41508752}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1743175002}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &91909877
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23910475516204494, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 91909875}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &91909878
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33491117337019956, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 91909875}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &94550649
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 94550650}
+  m_Layer: 5
+  m_Name: Brush Marble
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &94550650
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 94550649}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 572014665}
+  m_Father: {fileID: 1832814775}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &94561689
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 120602, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 94561691}
+  - component: {fileID: 94561690}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &94561690
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 94561689}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fef3ed62c0f3bbc4a9fca43ab8071aed, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  editTimePose: 2
+--- !u!4 &94561691
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 411020, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 94561689}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.627, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1311336093}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &95438063
 GameObject:
   m_ObjectHideFlags: 0
@@ -1450,6 +2193,154 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad,
     type: 3}
   m_PrefabInternal: {fileID: 96017144}
+--- !u!1 &99731267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1146112603474570, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 99731268}
+  - component: {fileID: 99731270}
+  - component: {fileID: 99731269}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &99731268
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4400542279083680, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 99731267}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.071510725, y: 0.5041232, z: 0.31151348}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1094083028}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &99731269
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23984080199532332, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 99731267}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &99731270
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33047811045835128, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 99731267}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &103874078
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1565485633822156, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 103874079}
+  m_Layer: 0
+  m_Name: Color Swatch (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &103874079
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4402014043787644, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 103874078}
+  m_LocalRotation: {x: -2.1605053e-14, y: -0.00000007375698, z: 0.000000031610053,
+    w: 1}
+  m_LocalPosition: {x: -1.1000069, y: 0.09998988, z: -1.8599988}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 430827531}
+  - {fileID: 1332202002}
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &109013842
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011008050412, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 109013843}
+  m_Layer: 0
+  m_Name: HandAttachments_R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &109013843
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000013929251140, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 109013842}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1948795073}
+  - {fileID: 789337755}
+  - {fileID: 1217729002}
+  - {fileID: 537749379}
+  - {fileID: 45922386}
+  - {fileID: 1624411947}
+  - {fileID: 1791992348}
+  - {fileID: 233744293}
+  - {fileID: 1147789264}
+  m_Father: {fileID: 1293942366}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &113997872
 GameObject:
   m_ObjectHideFlags: 0
@@ -1532,6 +2423,39 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &114110165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1964385924745020, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 114110166}
+  m_Layer: 0
+  m_Name: Color Swatch (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &114110166
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4802523517335348, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 114110165}
+  m_LocalRotation: {x: -2.1605053e-14, y: -0.00000007375698, z: 0.000000031610053,
+    w: 1}
+  m_LocalPosition: {x: -2.1300027, y: 0.099990875, z: 0.02000363}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1806894474}
+  - {fileID: 1143031935}
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &118904708
 GameObject:
   m_ObjectHideFlags: 0
@@ -1696,6 +2620,264 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &129030012
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1264697346749308, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 129030013}
+  - component: {fileID: 129030015}
+  - component: {fileID: 129030014}
+  m_Layer: 0
+  m_Name: Sphere L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &129030013
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4345983948861390, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129030012}
+  m_LocalRotation: {x: -4.3297806e-17, y: 0.7071068, z: 0.7071068, w: -4.3297806e-17}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 655833091}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &129030014
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23235550856869094, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129030012}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 043e6d1c9a26f5f46b53a5cd101324db, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &129030015
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33438619049999234, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129030012}
+  m_Mesh: {fileID: 4300002, guid: 0a969de86108bb448bd93c6901920346, type: 3}
+--- !u!1 &129176815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1941085101634066, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 129176816}
+  - component: {fileID: 129176818}
+  - component: {fileID: 129176817}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &129176816
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4670515554938888, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129176815}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.029344346, y: 0.9079779, z: 0.23574111}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 504093782}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &129176817
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23006531196866718, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129176815}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &129176818
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33793511063464050, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129176815}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &129239384
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1684143479167506, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 129239385}
+  - component: {fileID: 129239387}
+  - component: {fileID: 129239386}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &129239385
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4510774097013998, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129239384}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: -0.13456528, y: -0.29020917, z: -0.18628402}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1025233048}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &129239386
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23605619551897748, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129239384}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &129239387
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33665338913767018, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129239384}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &130672512
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 130672513}
+  m_Layer: 0
+  m_Name: Paint Cursor L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &130672513
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 130672512}
+  m_LocalRotation: {x: -0.16046898, y: -0.022173751, z: 0.122600265, w: 0.9791462}
+  m_LocalPosition: {x: 0.01, y: 1.513, z: -2.531}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 927448600}
+  - {fileID: 1114276460}
+  m_Father: {fileID: 1372450353}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -17.94, y: -4.8500004, z: 14.7560005}
 --- !u!1 &135678658
 GameObject:
   m_ObjectHideFlags: 0
@@ -1764,6 +2946,39 @@ MonoBehaviour:
   _horizontalAlignment: 1
   _verticalAlignment: 0
   _color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &137824213
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 137824214}
+  m_Layer: 0
+  m_Name: Pinch Painting RH
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &137824214
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 137824213}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1259462722}
+  - {fileID: 1675334812}
+  - {fileID: 1373135255}
+  - {fileID: 351986686}
+  - {fileID: 318198444}
+  m_Father: {fileID: 1311336093}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &146733977
 GameObject:
   m_ObjectHideFlags: 0
@@ -1913,6 +3128,78 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &147188497
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 147188498}
+  - component: {fileID: 147188500}
+  - component: {fileID: 147188499}
+  m_Layer: 0
+  m_Name: Quad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &147188498
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 147188497}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0068456, y: 1.0068476, z: 1.0068476}
+  m_Children: []
+  m_Father: {fileID: 1889300877}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!23 &147188499
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 147188497}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 331e75ea8d3d76a4abc4ecac995da3ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &147188500
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 147188497}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &148986034
 GameObject:
   m_ObjectHideFlags: 0
@@ -1983,8 +3270,117 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 573826044}
-  m_RootOrder: 7
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &150231448
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 150231449}
+  m_Layer: 0
+  m_Name: Brush Mode Emergeable Parent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &150231449
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 150231448}
+  m_LocalRotation: {x: 0.7257013, y: -0.00305488, z: 0.017484078, w: 0.687781}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.37499988, y: 0.37500018, z: 0.3750004}
+  m_Children:
+  - {fileID: 1455894659}
+  - {fileID: 159747818}
+  - {fileID: 1478040350}
+  - {fileID: 646267621}
+  - {fileID: 472929502}
+  m_Father: {fileID: 1832814775}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &154563685
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1060984296935008, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 154563686}
+  - component: {fileID: 154563688}
+  - component: {fileID: 154563687}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &154563686
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4456824273949620, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 154563685}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: -0.043644425, y: 0.029831516, z: -0.26380256}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2052765576}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &154563687
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23913908747603016, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 154563685}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &154563688
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33631446958194556, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 154563685}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &157615676
 GameObject:
   m_ObjectHideFlags: 0
@@ -2130,6 +3526,70 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DeactivateOnDisable: 0
   Transition: {fileID: 0}
+--- !u!1 &158968538
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1456317498955642, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 158968539}
+  m_Layer: 0
+  m_Name: Color Swatch (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &158968539
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4853495239723246, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 158968538}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -2.9939175, y: 1.11, z: -0.64}
+  m_LocalScale: {x: 0.3872106, y: 0.38720962, z: 0.38720992}
+  m_Children:
+  - {fileID: 1908323254}
+  - {fileID: 719820617}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &159747817
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 159747818}
+  m_Layer: 0
+  m_Name: Coming Soon Button (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &159747818
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 159747817}
+  m_LocalRotation: {x: -0.00000008940696, y: -0.000000010244547, z: -0.0000000025611369,
+    w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: -3.2}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
+  m_Children:
+  - {fileID: 273763614}
+  - {fileID: 1942113993}
+  - {fileID: 85683917}
+  m_Father: {fileID: 150231449}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!1 &161981564
 GameObject:
   m_ObjectHideFlags: 0
@@ -2330,6 +3790,78 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 166583402}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &166893241
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 166893242}
+  - component: {fileID: 166893244}
+  - component: {fileID: 166893243}
+  m_Layer: 0
+  m_Name: Capsule (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &166893242
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 166893241}
+  m_LocalRotation: {x: 0.63698936, y: 0.23173064, z: -0.26542696, w: 0.6856341}
+  m_LocalPosition: {x: 0.019100001, y: 0.010899994, z: -0.0056999936}
+  m_LocalScale: {x: 0.00402, y: 0.011380002, z: 0.0040199985}
+  m_Children: []
+  m_Father: {fileID: 47246601}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 85.204, y: -14.110001, z: -55.311}
+--- !u!23 &166893243
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 166893241}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &166893244
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 166893241}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &170834973
 Prefab:
   m_ObjectHideFlags: 0
@@ -2396,6 +3928,94 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
   m_PrefabInternal: {fileID: 170834973}
+--- !u!1 &175335082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1099131940468392, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 175335083}
+  m_Layer: 0
+  m_Name: Color Swatch (13)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &175335083
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4678180302718968, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 175335082}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 0.0027971268, y: 1.86, z: -0.71}
+  m_LocalScale: {x: 0.3872106, y: 0.38720962, z: 0.38720992}
+  m_Children:
+  - {fileID: 1922016324}
+  - {fileID: 1571408493}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &176873341
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 176873342}
+  m_Layer: 0
+  m_Name: '--------'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &176873342
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 176873341}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &181722600
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 181722601}
+  m_Layer: 0
+  m_Name: Ribbons
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &181722601
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 181722600}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1649983740}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &191400204
 GameObject:
   m_ObjectHideFlags: 0
@@ -2577,6 +4197,82 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 82e09e51c1efb98489fc03d6af9dfbec, type: 3}
   m_PrefabInternal: {fileID: 195053057}
+--- !u!1 &198100159
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1473101061290702, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 198100160}
+  - component: {fileID: 198100162}
+  - component: {fileID: 198100161}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &198100160
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4848031774322620, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 198100159}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.040646527, y: 0.27647516, z: -0.019967409}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 266988905}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &198100161
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23325253231294372, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 198100159}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &198100162
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33124690741797068, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 198100159}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &200622197
 GameObject:
   m_ObjectHideFlags: 0
@@ -2764,6 +4460,237 @@ Transform:
   m_Father: {fileID: 735003968}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &206834521
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1311336093}
+    m_Modifications:
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0.0107165575
+      objectReference: {fileID: 0}
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0.04131803
+      objectReference: {fileID: 0}
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0.3171697
+      objectReference: {fileID: 0}
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151435120617084, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0.075478025
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151435120617084, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0.1294075
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151435120617084, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 1.4405918
+      objectReference: {fileID: 0}
+    - target: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0.075478025
+      objectReference: {fileID: 0}
+    - target: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0.1294075
+      objectReference: {fileID: 0}
+    - target: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 1.4704567
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632168178802062, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 1.4704567
+      objectReference: {fileID: 0}
+    - target: {fileID: 4901869794248370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 1.4405918
+      objectReference: {fileID: 0}
+    - target: {fileID: 114805386573115904, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: _attachmentPoints
+      value: 1835014
+      objectReference: {fileID: 0}
+    - target: {fileID: 114807355752014248, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: pinkyKnuckle
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114517128394862370, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: pinkyKnuckle
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114807355752014248, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: pinkyMiddleJoint
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114517128394862370, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: pinkyMiddleJoint
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114807355752014248, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: pinkyDistalJoint
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 114517128394862370, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: pinkyDistalJoint
+      value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 4901869794248370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0.8627296
+      objectReference: {fileID: 0}
+    - target: {fileID: 4901869794248370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0.075480185
+      objectReference: {fileID: 0}
+    - target: {fileID: 4901869794248370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0.12941155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4901869794248370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.48296273
+      objectReference: {fileID: 0}
+    - target: {fileID: 4901869794248370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0.21282145
+      objectReference: {fileID: 0}
+    - target: {fileID: 4901869794248370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 1.249383
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632168178802062, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: -0.8627296
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632168178802062, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0.075480185
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632168178802062, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0.12941155
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632168178802062, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: 0.48296273
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632168178802062, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0.21999401
+      objectReference: {fileID: 0}
+    - target: {fileID: 4632168178802062, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 1.2404597
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151435120617084, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.8627302
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151435120617084, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: -0.48296311
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151435120617084, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -0.21283352
+      objectReference: {fileID: 0}
+    - target: {fileID: 4151435120617084, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 1.249381
+      objectReference: {fileID: 0}
+    - target: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.8627302
+      objectReference: {fileID: 0}
+    - target: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: -0.48296311
+      objectReference: {fileID: 0}
+    - target: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: -0.22000602
+      objectReference: {fileID: 0}
+    - target: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 1.2404577
+      objectReference: {fileID: 0}
+    - target: {fileID: 114807355752014248, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: _isTracked
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114517128394862370, guid: 80001c6c93c5068488198a82e151e3ff,
+        type: 2}
+      propertyPath: _isTracked
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1049534810953736, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 114807355752014248, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+    - {fileID: 114517128394862370, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+    - {fileID: 114805386573115904, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+    - {fileID: 114462628715354304, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+    - {fileID: 114479301565299396, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+    - {fileID: 114553000557697698, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+    - {fileID: 114990173483565386, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+    - {fileID: 114626281574833694, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+  m_ParentPrefab: {fileID: 100100000, guid: 80001c6c93c5068488198a82e151e3ff, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &206834522 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4139101302111182, guid: 80001c6c93c5068488198a82e151e3ff,
+    type: 2}
+  m_PrefabInternal: {fileID: 206834521}
+--- !u!4 &206834523 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4917671769262128, guid: 80001c6c93c5068488198a82e151e3ff,
+    type: 2}
+  m_PrefabInternal: {fileID: 206834521}
+--- !u!4 &206834524 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4481817357345236, guid: 80001c6c93c5068488198a82e151e3ff,
+    type: 2}
+  m_PrefabInternal: {fileID: 206834521}
+--- !u!4 &206834525 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 4411216943293902, guid: 80001c6c93c5068488198a82e151e3ff,
+    type: 2}
+  m_PrefabInternal: {fileID: 206834521}
 --- !u!1 &208762950
 GameObject:
   m_ObjectHideFlags: 0
@@ -2853,6 +4780,347 @@ Transform:
   m_Father: {fileID: 2060420804}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &222778846
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 222778850}
+  - component: {fileID: 222778849}
+  - component: {fileID: 222778848}
+  - component: {fileID: 222778847}
+  m_Layer: 0
+  m_Name: Thumbs up (response)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &222778847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 222778846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 0}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &222778848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 222778846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: dd6cdabe8a3991f499cb42cf4ec1f8fe, type: 2}
+  _wrapMode: 2
+--- !u!114 &222778849
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 222778846}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: ClearText
+            m_Mode: 1
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: 
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+--- !u!4 &222778850
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 222778846}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &225111328
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 225111329}
+  - component: {fileID: 225111331}
+  - component: {fileID: 225111330}
+  m_Layer: 0
+  m_Name: Things are getting crowded
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &225111329
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 225111328}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 20
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &225111330
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 225111328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 640536046}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &225111331
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 225111328}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 5f69b7c7a87058d4580e04a478815607, type: 2}
+  _wrapMode: 2
+--- !u!1 &227293553
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 227293554}
+  - component: {fileID: 227293556}
+  - component: {fileID: 227293555}
+  m_Layer: 0
+  m_Name: Imma create a palm tree!
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &227293554
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 227293553}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &227293555
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 227293553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1158073986}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &227293556
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 227293553}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 17e41049430064d4c952a87c969e4c98, type: 2}
+  _wrapMode: 2
+--- !u!1 &230986566
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 230986567}
+  m_Layer: 5
+  m_Name: WearableUI Objects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &230986567
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 230986566}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 371309393}
+  m_Father: {fileID: 1832814775}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &233744292
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011803222426, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 233744293}
+  m_Layer: 0
+  m_Name: Pinky
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &233744293
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000010471733076, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 233744292}
+  m_LocalRotation: {x: 0.8574678, y: 0.008783347, z: 0.08120872, w: -0.50801295}
+  m_LocalPosition: {x: -0.1790095, y: 1.5368698, z: 1.1936821}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 667667484}
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &236630786
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1020638032594494, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 236630787}
+  - component: {fileID: 236630789}
+  - component: {fileID: 236630788}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &236630787
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4765927224180316, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 236630786}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.069024, y: 0.3754548, z: 0.3221269}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1851737852}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &236630788
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23637088939750418, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 236630786}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &236630789
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33941250163320746, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 236630786}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &236742723
 GameObject:
   m_ObjectHideFlags: 0
@@ -2884,152 +5152,142 @@ Transform:
   m_Father: {fileID: 1185104850}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &249459858
-Mesh:
+--- !u!1 &237921211
+GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 1577816721436154, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
   m_PrefabInternal: {fileID: 0}
-  m_Name: Ribbon Circle Mesh
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 1536
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 256
-    localAABB:
-      m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-      m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
-  m_Skin: []
-  m_VertexData:
-    serializedVersion: 2
-    m_VertexCount: 256
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 6144
-    _typelessdata: d9cef73c6f12833900000000a681353fa881343f67393ebc45b6f33c6f128339000000003e8034bf1e83353f822e3dbcd9cef73c6f1283b900000000a681353fa88134bf233d3e3c45b6f33c6f1283b9000000003e8034bf1e8335bfbb2a3d3c5e9df63c6f128339c15042bb5d57343f9c81343f59fda5bdd889f23c6f128339871a3fbbf2eb33bf1383353f8d026c3d5e9df63c6f1283b9c15042bb87ec343f9c8134bf5c536dbdd889f23c6f1283b9871a3fbb9b5733bf148335bf0912a53de30bf33c6f1283393861c1bb6270313fa581343f2a4d19be7507ef3c6f128339f42ebebbfb9b31bf1e83353f8c42013ee30bf33c6f1283b93861c1bb4699323fa58134bfd2fa01be7507ef3c6f1283b9f42ebebbbf7430bf1e8335bfb973183e3023ed3c6f128339a6de0fbc02d42c3f9e81343fa2215ebec437e93c6f128339e07d0dbc39962dbf1683353fc745463e3023ed3c6f1283b9a6de0fbcc48d2e3f9c8134bf956047bec437e93c6f1283b9e07d0dbce9de2bbf188335bf9de65c3edaf1e43c6f128339fea93dbc7e8d263fa281343f476990be1829e13c6f12833972873abc71e427bf1983353f17b0843edaf1e43c6f1283b9fea93dbcded3283fa08134bf4f6d85be1829e13c6f1283b972873abc49a125bf198335bf759c8f3e108cda3c6f128339bba169bc64ac1e3f9d81343fa95db0be4eefd63c6f12833923c565bcc89420bf1083353f37f6a43e108cda3c6f1283b9bba169bcc579213f988134bf79e1a5be4eefd63c6f1283b923c565bc5dcb1dbf158335bf8c63af3e790bce3c6f128339bbac89bc1544153f9b81343f3d9fcebe9da3ca3c6f1283392d6687bc24b917bf1d83353f86a5c33e790bce3c6f1283b9bbac89bc8591183fa78134bf84bcc4be9da3ca3c6f1283b92d6687bc647014bf128335bf427acd3ee48ebf3c6f1283392d359dbcb06b0a3fac81343f5ee3eabe5464bc3c6f128339f79b9abc7a670dbf2183353f8d72e03ee48ebf3c6f1283b92d359dbc22310e3fa88134bfa0b2e1be5464bc3c6f1283b9f79b9abc65a709bf268335bf3a96e93e093aaf3c6f128339083aafbc567cfc3e9f81343f3b7202bf9554ac3c6f1283399454acbc3eb901bf1783353f3e16fb3e093aaf3c6f1283b9083aafbc3b72023f9f8134bf567cfcbe9554ac3c6f1283b99454acbc3d16fbbe178335bf3eb9013f2e359d3c6f128339e38ebfbca0b2e13ea981343f23310ebff89b9a3c6f1283395364bcbc3a96e9be2683353f64a7093f2e359d3c6f1283b9e38ebfbc5ee3ea3eac8134bfb06b0abff89b9a3c6f1283b95364bcbc8d72e0be218335bf7a670d3fbcac893c6f128339780bcebc80bcc43ea581343f859118bf2e66873c6f1283399ca3cabc3f7acdbe1283353f6470143fbcac893c6f1283b9780bcebc3b9fce3e9b8134bf144415bf2e66873c6f1283b99ca3cabc86a5c3be1d8335bf27b9173fbca1693c6f1283390f8cdabc78e1a53e9a81343fc67921bf24c5653c6f1283394defd6bc8963afbe1483353f5ecb1d3fbca1693c6f1283b90f8cdabca75db03e9c8134bf64ac1ebf24c5653c6f1283b94defd6bc36f6a4be108335bfc794203fffa93d3c6f128339d9f1e4bc506d853ea081343fddd328bf73873a3c6f1283391729e1bc769c8fbe1983353f49a1253fffa93d3c6f1283b9d9f1e4bc4869903ea18134bf7d8d26bf73873a3c6f1283b91729e1bc18b084be198335bf70e4273fa8de0f3c6f1283392f23edbc9760473e9c81343fc58d2ebfe27d0d3c6f128339c337e9bc9ee65cbe1883353fe6de2b3fa8de0f3c6f1283b92f23edbca2215e3e9e8134bf01d42cbfe27d0d3c6f1283b9c337e9bcc94546be158335bf39962d3f3c61c13b6f128339e20bf3bce6fa013ea581343f459932bff82ebe3b6f1283397407efbcc27318be1d83353fbe74303f3c61c13b6f1283b9e20bf3bc344d193ea58134bf627031bff82ebe3b6f1283b97407efbca04201be1e8335bffb9b313fca50423b6f1283395e9df6bc34536d3d9b81343f87ec34bf901a3f3b6f128339d889f2bc1e12a5bd1483353f9b57333fca50423b6f1283b95e9df6bc6cfda53d9c8134bf5c5734bf901a3f3b6f1283b9d889f2bc64026cbd138335bff2eb333fea4918316f128339d8cef7bc073a3ebca781343fa68135bf84c515316f12833944b6f3bc5d2b3dbc1e83353f3e80343fea4918316f1283b9d8cef7bc073a3e3ca88134bfa68135bf84c515316f1283b944b6f3bc5d2b3d3c1e8335bf3e80343fb75042bb6f1283395e9df6bc46fda5bd9c81343f5d5734bf7d1a3fbb6f128339d889f2bc40026c3d1283353ff3eb333fb75042bb6f1283b95e9df6bc0d536dbd9b8134bf88ec34bf7d1a3fbb6f1283b9d889f2bcf811a53d168335bf9c57333f3261c1bb6f128339e30bf3bc2b4d19bea581343f627031bfee2ebebb6f1283397507efbc8c42013e1e83353ffb9b313f3261c1bb6f1283b9e30bf3bcd3fa01bea68134bf459932bfee2ebebb6f1283b97507efbcb973183e1d8335bfbe74303fa3de0fbc6f1283393023edbca2215ebe9e81343f02d42cbfdd7d0dbc6f128339c437e9bcc745463e1683353f39962d3fa3de0fbc6f1283b93023edbc956047be9c8134bfc48d2ebfdd7d0dbc6f1283b9c437e9bc9de65c3e188335bfe9de2b3ffba93dbc6f128339daf1e4bc476990bea281343f7e8d26bf6f873abc6f1283391829e1bc17b0843e1983353f71e4273ffba93dbc6f1283b9daf1e4bc4f6d85bea08134bfded328bf6f873abc6f1283b91829e1bc759c8f3e198335bf49a1253fb8a169bc6f128339108cdabca75db0be9c81343f64ac1ebf20c565bc6f1283394eefd6bc36f6a43e1083353fc794203fb8a169bc6f1283b9108cdabc78e1a5be9a8134bfc67921bf20c565bc6f1283b94eefd6bc8b63af3e148335bf5ecb1d3fbaac89bc6f128339790bcebc3c9fcebe9b81343f154415bf2c6687bc6f1283399da3cabc85a5c33e1d83353f26b9173fbaac89bc6f1283b9790bcebc80bcc4bea68134bf859118bf2c6687bc6f1283b99da3cabc3f7acd3e128335bf6470143f2c359dbc6f128339e48ebfbc5be3eabeac81343fb36b0abff69b9abc6f1283395464bcbc8972e03e2283353f79670d3f2c359dbc6f1283b9e48ebfbc9db2e1bea98134bf23310ebff69b9abc6f1283b95464bcbc3696e93e258335bf67a7093f083aafbc6f128339093aafbc3b7202bfa181343f517cfcbe9454acbc6f1283399554acbc3e16fb3e1683353f40b9013f083aafbc6f1283b9093aafbc567cfcbe9c8134bf3e7202bf9454acbc6f1283b99554acbc3eb9013f1a8335bf3816fb3ee28ebfbc6f1283392e359dbc25310ebfa881343f9eb2e1be5264bcbc6f128339f89b9abc66a7093f2783353f3396e93ee28ebfbc6f1283b92e359dbcb36b0abfaf8134bf59e3eabe5264bcbc6f1283b9f89b9abc7b670d3f1f8335bf8a72e03e770bcebc6f128339bcac89bc859118bfa781343f84bcc4be9ba3cabc6f1283392e6687bc6470143f1283353f427acd3e770bcebc6f1283b9bcac89bc154415bf9b8134bf3d9fcebe9ba3cabc6f1283b92e6687bc24b9173f1d8335bf86a5c33e0e8cdabc6f128339bda169bcc57921bf9881343f79e1a5be4cefd6bc6f12833925c565bc5dcb1d3f1583353f8b63af3e0e8cdabc6f1283b9bda169bc64ac1ebf9d8134bfa95db0be4cefd6bc6f1283b925c565bcc794203f108335bf37f6a43ed8f1e4bc6f12833900aa3dbcded328bfa181343f516d85be1629e1bc6f12833974873abc4aa1253f1a83353f779c8f3ed8f1e4bc6f1283b900aa3dbc7d8d26bfa18134bf486990be1629e1bc6f1283b974873abc70e4273f198335bf18b0843e2e23edbc6f128339a9de0fbcc58d2ebf9c81343f976047bec237e9bc6f128339e37d0dbce7de2b3f1983353f9fe65c3e2e23edbc6f1283b9a9de0fbc01d42cbf9e8134bfa2215ebec237e9bc6f1283b9e37d0dbc38962d3f148335bfc745463ee10bf3bc6f1283393e61c1bb459932bfa681343fe7fa01be7307efbc6f128339fa2ebebbbe74303f1d83353fc373183ee10bf3bc6f1283b93e61c1bb627031bfa58134bf354d19be7307efbc6f1283b9fa2ebebbfa9b313f1e8335bfa042013e5d9df6bc6f128339cf5042bb88ec34bf9b81343f35536dbdd789f2bc6f128339951a3fbb9b57333f1583353f1f12a53d5d9df6bc6f1283b9cf5042bb5c5734bf9c8134bf6dfda5bdd789f2bc6f1283b9951a3fbbf3eb333f148335bf67026c3dd7cef7bc6f128339228071b1a68135bfa781343f073a3e3c43b6f3bc6f12833940826db13e80343f1f83353f5e2b3d3cd7cef7bc6f1283b9228071b1a68135bfa78134bf073a3ebc43b6f3bc6f1283b940826db13e80343f1f8335bf5e2b3dbc5d9df6bc6f128339b150423b5c5734bf9c81343f46fda53dd789f2bc6f128339771a3f3bf3eb333f1283353f40026cbd5d9df6bc6f1283b9b150423b88ec34bf9b8134bf0d536d3dd789f2bc6f1283b9771a3f3b9b57333f158335bff611a5bde20bf3bc6f1283392f61c13b637031bfa481343f2a4d193e7407efbc6f128339eb2ebe3bfb9b313f1e83353f8c4201bee20bf3bc6f1283b92f61c13b469932bfa68134bfd3fa013e7407efbc6f1283b9eb2ebe3bbf74303f1e8335bfb97318be2f23edbc6f128339a2de0f3c01d42cbf9e81343fa2215e3ec337e9bc6f128339dc7d0d3c39962d3f1583353fc74546be2f23edbc6f1283b9a2de0f3cc58d2ebf9b8134bf9560473ec337e9bc6f1283b9dc7d0d3ce7de2b3f198335bf9ee65cbed9f1e4bc6f128339f9a93d3c7d8d26bfa081343f4869903e1729e1bc6f1283396d873a3c70e4273f1983353f18b084bed9f1e4bc6f1283b9f9a93d3cded328bfa18134bf516d853e1729e1bc6f1283b96d873a3c4aa1253f1a8335bf779c8fbe0f8cdabc6f128339b6a1693c64ac1ebf9c81343fa75db03e4defd6bc6f1283391ec5653cc794203f1083353f36f6a4be0f8cdabc6f1283b9b6a1693cc57921bf998134bf77e1a53e4defd6bc6f1283b91ec5653c5ecb1d3f148335bf8b63afbe780bcebc6f128339b9ac893c154415bf9b81343f3c9fce3e9ca3cabc6f1283392b66873c27b9173f1e83353f86a5c3be780bcebc6f1283b9b9ac893c859118bfa68134bf80bcc43e9ca3cabc6f1283b92b66873c6470143f128335bf3f7acdbee38ebfbc6f1283392b359d3cb36b0abfac81343f5be3ea3e5364bcbc6f128339f59b9a3c79670d3f2283353f8972e0bee38ebfbc6f1283b92b359d3c23310ebfa98134bf9db2e13e5364bcbc6f1283b9f59b9a3c67a7093f258335bf3696e9be083aafbc6f128339073aaf3c507cfcbea081343f3a72023f9454acbc6f1283399354ac3c40b9013f1683353f3e16fbbe083aafbc6f1283b9073aaf3c3e7202bf9c8134bf567cfc3e9454acbc6f1283b99354ac3c3816fb3e1a8335bf3eb901bf2d359dbc6f128339e18ebf3c9eb2e1bea881343f25310e3ff79b9abc6f1283395164bc3c3296e93e2683353f65a709bf2d359dbc6f1283b9e18ebf3c57e3eabeae8134bfb26b0a3ff79b9abc6f1283b95164bc3c8a72e03e1f8335bf7b670dbfbbac89bc6f128339760bce3c84bcc4bea781343f8591183f2d6687bc6f1283399aa3ca3c427acd3e1283353f647014bfbbac89bc6f1283b9760bce3c3d9fcebe9b8134bf1544153f2d6687bc6f1283b99aa3ca3c86a5c33e1d8335bf24b917bfbba169bc6f1283390d8cda3c79e1a5be9881343fc579213f23c565bc6f1283394befd63c8b63af3e1583353f5dcb1dbfbba169bc6f1283b90d8cda3ca95db0be9d8134bf64ac1e3f23c565bc6f1283b94befd63c37f6a43e108335bfc79420bffea93dbc6f128339d7f1e43c506d85bea081343fddd3283f72873abc6f1283391529e13c769c8f3e1983353f49a125bffea93dbc6f1283b9d7f1e43c486990bea18134bf7d8d263f72873abc6f1283b91529e13c18b0843e198335bf70e427bfa7de0fbc6f1283392d23ed3c976047be9c81343fc58d2e3fe17d0dbc6f128339c137e93c9ee65c3e1883353fe6de2bbfa7de0fbc6f1283b92d23ed3ca2215ebe9e8134bf01d42c3fe17d0dbc6f1283b9c137e93cc945463e158335bf39962dbf3a61c1bb6f128339e00bf33ce7fa01bea681343f4599323ff62ebebb6f1283397207ef3cc373183e1d83353fbe7430bf3a61c1bb6f1283b9e00bf33c354d19bea58134bf6270313ff62ebebb6f1283b97207ef3ca042013e1e8335bffa9b31bfc85042bb6f1283395c9df63c35536dbd9b81343f87ec343f8e1a3fbb6f128339d689f23c2012a53d1583353f9b5733bfc85042bb6f1283b95c9df63c6efda5bd9c8134bf5c57343f8e1a3fbb6f1283b9d689f23c67026c3d148335bff2eb33bf56c011b16f128339d6cef73c083a3e3ca681343fa681353f9a570fb16f12833942b6f33c5e2b3d3c1e83353f3e8034bf56c011b16f1283b9d6cef73c083a3ebca68134bfa681353f9a570fb16f1283b942b6f33c5e2b3dbc1e8335bf3e8034bfb650423b6f1283395c9df63c48fda53d9d81343f5d57343f7c1a3f3b6f128339d689f23c42026cbd1483353ff3eb33bfb650423b6f1283b95c9df63c0f536d3d9b8134bf88ec343f7c1a3f3b6f1283b9d689f23cf811a5bd158335bf9b5733bf3161c13b6f128339e10bf33c2a4d193ea481343f6370313fed2ebe3b6f1283397307ef3c8c4201be1e83353ffb9b31bf3161c13b6f1283b9e10bf33cd3fa013ea68134bf4699323fed2ebe3b6f1283b97307ef3cb97318be1d8335bfbf7430bfa3de0f3c6f1283392e23ed3ca2215e3e9e81343f01d42c3fdd7d0d3c6f128339c237e93cc74546be1583353f39962dbfa3de0f3c6f1283b92e23ed3c9560473e9b8134bfc58d2e3fdd7d0d3c6f1283b9c237e93c9ee65cbe198335bfe7de2bbffaa93d3c6f128339d8f1e43c4869903ea081343f7d8d263f6e873a3c6f1283391629e13c18b084be1983353f70e427bffaa93d3c6f1283b9d8f1e43c506d853ea08134bfddd3283f6e873a3c6f1283b91629e13c769c8fbe198335bf49a125bfb7a1693c6f1283390e8cda3ca95db03e9d81343f64ac1e3f1fc5653c6f1283394cefd63c37f6a4be1083353fc89420bfb7a1693c6f1283b90e8cda3c79e1a53e988134bfc579213f1fc5653c6f1283b94cefd63c8c63afbe158335bf5dcb1dbfb9ac893c6f128339770bce3c3d9fce3e9b81343f1544153f2b66873c6f1283399ba3ca3c86a5c3be1d83353f24b917bfb9ac893c6f1283b9770bce3c84bcc43ea78134bf8591183f2b66873c6f1283b99ba3ca3c427acdbe128335bf647014bf2b359d3c6f128339e28ebf3c54e3ea3eac81343fb56b0a3ff59b9a3c6f1283395264bc3c8872e0be2183353f7c670dbf2b359d3c6f1283b9e28ebf3c9ab2e13ea88134bf24310e3ff59b9a3c6f1283b95264bc3c2f96e9be268335bf69a709bf073aaf3c6f128339083aaf3c3e72023f9f81343f517cfc3e9354ac3c6f1283399454ac3c3916fbbe1983353f40b901bf073aaf3c6f1283b9083aaf3c517cfc3e9f8134bf3e72023f9354ac3c6f1283b99454ac3c40b901bf178335bf3816fbbee18ebf3c6f1283392c359d3c24310e3fa881343f99b2e13e5164bc3c6f128339f69b9a3c68a709bf2583353f2f96e9bee18ebf3c6f1283b92c359d3cb56b0a3fac8134bf54e3ea3e5164bc3c6f1283b9f69b9a3c7b670dbf218335bf8772e0be760bce3c6f128339baac893c8591183fa781343f84bcc43e9aa3ca3c6f1283392c66873c647014bf1283353f427acdbe760bce3c6f1283b9baac893c1544153f9b8134bf3d9fce3e9aa3ca3c6f1283b92c66873c24b917bf1d8335bf86a5c3be0d8cda3c6f128339b9a1693cc579213f9881343f79e1a53e4befd63c6f12833921c5653c5dcb1dbf1583353f8b63afbe0d8cda3c6f1283b9b9a1693c64ac1e3f9d8134bfa95db03e4befd63c6f1283b921c5653cc79420bf108335bf37f6a4bed7f1e43c6f128339fca93d3cded3283fa181343f516d853e1529e13c6f12833970873a3c4aa125bf1a83353f779c8fbed7f1e43c6f1283b9fca93d3c7d8d263fa18134bf4869903e1529e13c6f1283b970873a3c70e427bf198335bf18b084be2d23ed3c6f128339a5de0f3cc58d2e3f9c81343f9760473ec137e93c6f128339df7d0d3ce7de2bbf1983353f9fe65cbe2d23ed3c6f1283b9a5de0f3c01d42c3f9e8134bfa2215e3ec137e93c6f1283b9df7d0d3c38962dbf148335bfc74546bee00bf33c6f1283393661c13b4599323fa681343fe7fa013e7207ef3c6f128339f22ebe3bbe7430bf1d83353fc37318bee00bf33c6f1283b93661c13b6270313fa58134bf354d193e7207ef3c6f1283b9f22ebe3bfa9b31bf1e8335bfa04201be5c9df63c6f128339c050423b87ec343f9b81343f25546d3dd689f23c6f128339861a3f3b9a5733bf1483353f5a12a5bd5c9df63c6f1283b9c050423b5b57343f9c8134bfa9fda53dd689f23c6f1283b9861a3f3bf1eb33bf138335bf57036cbd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-    m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 237921212}
+  - component: {fileID: 237921214}
+  - component: {fileID: 237921213}
+  m_Layer: 0
+  m_Name: CleaningBasin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &237921212
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4501490878955294, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 237921211}
+  m_LocalRotation: {x: 0.3418853, y: 0.61896235, z: -0.61896235, w: -0.34188545}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: -0.7144517, y: -0.30708742, z: -0.47402832}
+  m_Children: []
+  m_Father: {fileID: 1194378814}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &237921213
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23652886838771572, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 237921211}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &237921214
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33202433526127206, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 237921211}
+  m_Mesh: {fileID: 4300000, guid: a130c5a83e325b743a07a8c4b29d7633, type: 3}
+--- !u!1 &250519632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010386218668, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 250519633}
+  m_Layer: 0
+  m_Name: Ring
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &250519633
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000014074252918, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 250519632}
+  m_LocalRotation: {x: -0.83803123, y: -0.026038805, z: -0.013268284, w: 0.54483914}
+  m_LocalPosition: {x: 0.20643218, y: 1.5600717, z: 1.1891674}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &255535907
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010284589124, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 255535908}
+  m_Layer: 0
+  m_Name: Pinch Detector L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &255535908
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012042185654, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 255535907}
+  m_LocalRotation: {x: 0.4405507, y: -0.82120776, z: 0.12365994, w: -0.3409417}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 606411737}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &256381096
 GameObject:
   m_ObjectHideFlags: 0
@@ -3166,6 +5424,66 @@ Transform:
   m_Father: {fileID: 1127886609}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0.5207, y: -8.3307, z: 82.033}
+--- !u!1 &266988904
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1905812849492588, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 266988905}
+  m_Layer: 0
+  m_Name: Color Swatch (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &266988905
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4761128378826306, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 266988904}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -2.1261444, y: 1.11, z: -0.64}
+  m_LocalScale: {x: 0.3872106, y: 0.38720962, z: 0.38720992}
+  m_Children:
+  - {fileID: 198100160}
+  - {fileID: 495279505}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &269842663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 269842664}
+  m_Layer: 0
+  m_Name: '--------'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &269842664
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 269842663}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &270074877
 GameObject:
   m_ObjectHideFlags: 0
@@ -3434,6 +5752,76 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 10
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &273763613
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 159747818}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 3300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &273763614 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 273763613}
 --- !u!1 &274604375
 GameObject:
   m_ObjectHideFlags: 0
@@ -3656,6 +6044,158 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 278921675}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &285073528
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1086821866411504, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 285073529}
+  - component: {fileID: 285073531}
+  - component: {fileID: 285073530}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &285073529
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4507831050793652, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 285073528}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.109879375, y: 0.20479386, z: 0.01872692}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 752051449}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &285073530
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23147480860517598, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 285073528}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &285073531
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33876363217473958, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 285073528}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &296206385
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1753197610624666, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 296206386}
+  - component: {fileID: 296206388}
+  - component: {fileID: 296206387}
+  m_Layer: 0
+  m_Name: X Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &296206386
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4926825741396632, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 296206385}
+  m_LocalRotation: {x: -0.011035759, y: -0.7070207, z: 0.7070207, w: -0.011035711}
+  m_LocalPosition: {x: 0.14, y: -0.16, z: -0.32}
+  m_LocalScale: {x: 2.9937556, y: 3.9463773, z: 1.8985125}
+  m_Children: []
+  m_Father: {fileID: 887154784}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 89.981, y: 0, z: 181.736}
+--- !u!23 &296206387
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23247931753651520, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 296206385}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 32a515fad327e56409c83340eb428767, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &296206388
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33096208213610512, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 296206385}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &296896102
 GameObject:
   m_ObjectHideFlags: 0
@@ -3787,6 +6327,82 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &299680013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1069918116279704, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 299680014}
+  - component: {fileID: 299680016}
+  - component: {fileID: 299680015}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &299680014
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4603286101371876, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 299680013}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.14754926, y: -0.087348275, z: 0.5014728}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 872341593}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &299680015
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23251655901268920, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 299680013}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &299680016
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33466424833475380, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 299680013}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &301072888
 GameObject:
   m_ObjectHideFlags: 0
@@ -3936,6 +6552,230 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &305345372
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 305345373}
+  - component: {fileID: 305345375}
+  - component: {fileID: 305345374}
+  m_Layer: 0
+  m_Name: Sphere (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &305345373
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 305345372}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.003000001, y: 0.009600006, z: -0.027099967}
+  m_LocalScale: {x: 0.0065570786, y: 0.0065570744, z: 0.0065570744}
+  m_Children: []
+  m_Father: {fileID: 47246601}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &305345374
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 305345372}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &305345375
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 305345372}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &305711192
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1521630053127656, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 305711193}
+  - component: {fileID: 305711195}
+  - component: {fileID: 305711194}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &305711193
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4095093367567392, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 305711192}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.03382646, y: 0.3825061, z: -0.061122768}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1341977917}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &305711194
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23488208335251204, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 305711192}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &305711195
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33086178234741046, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 305711192}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &307408444
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1654293491991992, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 307408445}
+  - component: {fileID: 307408447}
+  - component: {fileID: 307408446}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &307408445
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4936017179855268, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 307408444}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.04345894, y: 0.71741694, z: -0.0077333413}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1414023800}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &307408446
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23399410045037384, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 307408444}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &307408447
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33944331155984734, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 307408444}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!43 &317808776
 Mesh:
   m_ObjectHideFlags: 3
@@ -4022,7 +6862,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 2112
-    _typelessdata: 1da10cbd5c1db43a000000000000803f0000803f0000803f0000803f0000a43d00000a3f00000000000000005dd6eabc5c1db43a000000000000803f0000803f0000803f0000803f0000e83d00000a3f00000000000000005dd6eabc2045c3bb000000000000803f0000803f0000803f0000803f0000e83d0000153f00000000000000001da10cbd2045c3bb000000000000803f0000803f0000803f0000803f0000a43d0000153f0000000000000000501be8bc84f9723b000000000000803f0000803f0000803f0000803f0000a43d0000233f00000000000000004c7eb1bc84f9723b000000000000803f0000803f0000803f0000803f0000f43d0000233f00000000000000004c7eb1bcec58b8bb000000000000803f0000803f0000803f0000803f0000f43d0000313f0000000000000000501be8bcec58b8bb000000000000803f0000803f0000803f0000803f0000a43d0000313f00000000000000003fc3aebc5c1db43a000000000000803f0000803f0000803f0000803f0080053f00001c3e0000000000000000764c70bc5c1db43a000000000000803f0000803f0000803f0000803f00800f3f00001c3e0000000000000000764c70bc2045c3bb000000000000803f0000803f0000803f0000803f00800f3f0000483e00000000000000003fc3aebc2045c3bb000000000000803f0000803f0000803f0000803f0080053f0000483e0000000000000000774c70bc5c1db43a000000000000803f0000803f0000803f0000803f0080053f00001c3e0000000000000000701203bc5c1db43a000000000000803f0000803f0000803f0000803f00800f3f00001c3e0000000000000000701203bc2045c3bb000000000000803f0000803f0000803f0000803f00800f3f0000483e0000000000000000774c70bc2045c3bb000000000000803f0000803f0000803f0000803f0080053f0000483e0000000000000000701203bc5c1db43a000000000000803f0000803f0000803f0000803f0000c43d0000153f0000000000000000daea18bb5c1db43a000000000000803f0000803f0000803f0000803f0000043e0000153f0000000000000000daea18bb2045c3bb000000000000803f0000803f0000803f0000803f0000043e0000203f0000000000000000701203bc2045c3bb000000000000803f0000803f0000803f0000803f0000c43d0000203f000000000000000042c32ebb5c1db43a000000000000803f0000803f0000803f0000803f0000e83d0000f23e00000000000000006e12833b5c1db43a000000000000803f0000803f0000803f0000803f00001c3e0000f23e00000000000000006e12833b2045c3bb000000000000803f0000803f0000803f0000803f00001c3e0000043f000000000000000042c32ebb2045c3bb000000000000803f0000803f0000803f0000803f0000e83d0000043f0000000000000000744c703b8480a2bb000000000000803f0000803f0000803f0000803f0000e43d0000da3e0000000000000000a2fe8d3b8480a2bb000000000000803f0000803f0000803f0000803f0000ec3d0000da3e0000000000000000a2fe8d3bec58b8bb000000000000803f0000803f0000803f0000803f0000ec3d0000dc3e0000000000000000744c703bec58b8bb000000000000803f0000803f0000803f0000803f0000e43d0000dc3e00000000000000004160e53b5c1db43a000000000000803f0000803f0000803f0000803f0000a43d00000a3f0000000000000000da874f3c5c1db43a000000000000803f0000803f0000803f0000803f0000e83d00000a3f0000000000000000da874f3c2045c3bb000000000000803f0000803f0000803f0000803f0000e83d0000153f00000000000000004160e53b2045c3bb000000000000803f0000803f0000803f0000803f0000a43d0000153f0000000000000000da874f3c5c1db43a000000000000803f0000803f0000803f0000803f0080053f00001c3e0000000000000000f1609e3c5c1db43a000000000000803f0000803f0000803f0000803f00800f3f00001c3e0000000000000000f1609e3c2045c3bb000000000000803f0000803f0000803f0000803f00800f3f0000483e0000000000000000da874f3c2045c3bb000000000000803f0000803f0000803f0000803f0080053f0000483e0000000000000000fe1ba13c84f9723b000000000000803f0000803f0000803f0000803f0000a43d0000153f000000000000000066f4b63c84f9723b000000000000803f0000803f0000803f0000803f0000c43d0000153f000000000000000066f4b63cec58b8bb000000000000803f0000803f0000803f0000803f0000c43d0000233f0000000000000000fe1ba13cec58b8bb000000000000803f0000803f0000803f0000803f0000a43d0000233f000000000000000073afb93c5c1db43a000000000000803f0000803f0000803f0000803f0080053f00001c3e0000000000000000774cf03c5c1db43a000000000000803f0000803f0000803f0000803f00800f3f00001c3e0000000000000000774cf03c2045c3bb000000000000803f0000803f0000803f0000803f00800f3f0000483e000000000000000073afb93c2045c3bb000000000000803f0000803f0000803f0000803f0080053f0000483e00000000000000008407f33c5c1db43a000000000000803f0000803f0000803f0000803f0000000000002d3f0000000000000000a3fe0d3d5c1db43a000000000000803f0000803f0000803f0000803f0000f03c00002d3f0000000000000000a3fe0d3dec58b8bb000000000000803f0000803f0000803f0000803f0000f03c0080373f00000000000000008407f33cec58b8bb000000000000803f0000803f0000803f0000803f000000000080373f0000000000000000
+    _typelessdata: 1da10cbd5c1db43a000000000000803f0000803f0000803f0000803f00005c3f00008f3e00000000000000005dd6eabc5c1db43a000000000000803f0000803f0000803f0000803f0080643f00008f3e00000000000000005dd6eabc2045c3bb000000000000803f0000803f0000803f0000803f0080643f0000a53e00000000000000001da10cbd2045c3bb000000000000803f0000803f0000803f0000803f00005c3f0000a53e0000000000000000501be8bc84f9723b000000000000803f0000803f0000803f0000803f00005c3f0000a53e00000000000000004c7eb1bc84f9723b000000000000803f0000803f0000803f0000803f0000663f0000a53e00000000000000004c7eb1bcec58b8bb000000000000803f0000803f0000803f0000803f0000663f0000c13e0000000000000000501be8bcec58b8bb000000000000803f0000803f0000803f0000803f00005c3f0000c13e00000000000000003fc3aebc5c1db43a000000000000803f0000803f0000803f0000803f0000743f0000803e0000000000000000764c70bc5c1db43a000000000000803f0000803f0000803f0000803f00007e3f0000803e0000000000000000764c70bc2045c3bb000000000000803f0000803f0000803f0000803f00007e3f0000963e00000000000000003fc3aebc2045c3bb000000000000803f0000803f0000803f0000803f0000743f0000963e0000000000000000774c70bc5c1db43a000000000000803f0000803f0000803f0000803f0000743f0000803e0000000000000000701203bc5c1db43a000000000000803f0000803f0000803f0000803f00007e3f0000803e0000000000000000701203bc2045c3bb000000000000803f0000803f0000803f0000803f00007e3f0000963e0000000000000000774c70bc2045c3bb000000000000803f0000803f0000803f0000803f0000743f0000963e0000000000000000701203bc5c1db43a000000000000803f0000803f0000803f0000803f0000063f00009a3e0000000000000000daea18bb5c1db43a000000000000803f0000803f0000803f0000803f00800e3f00009a3e0000000000000000daea18bb2045c3bb000000000000803f0000803f0000803f0000803f00800e3f0000b03e0000000000000000701203bc2045c3bb000000000000803f0000803f0000803f0000803f0000063f0000b03e000000000000000042c32ebb5c1db43a000000000000803f0000803f0000803f0000803f0000f83e0000b23e00000000000000006e12833b5c1db43a000000000000803f0000803f0000803f0000803f0000063f0000b23e00000000000000006e12833b2045c3bb000000000000803f0000803f0000803f0000803f0000063f0000c83e000000000000000042c32ebb2045c3bb000000000000803f0000803f0000803f0000803f0000f83e0000c83e0000000000000000744c703b8480a2bb000000000000803f0000803f0000803f0000803f0000563f0000623e0000000000000000a2fe8d3b8480a2bb000000000000803f0000803f0000803f0000803f0000573f0000623e0000000000000000a2fe8d3bec58b8bb000000000000803f0000803f0000803f0000803f0000573f0000663e0000000000000000744c703bec58b8bb000000000000803f0000803f0000803f0000803f0000563f0000663e00000000000000004160e53b5c1db43a000000000000803f0000803f0000803f0000803f00005c3f00008f3e0000000000000000da874f3c5c1db43a000000000000803f0000803f0000803f0000803f0080643f00008f3e0000000000000000da874f3c2045c3bb000000000000803f0000803f0000803f0000803f0080643f0000a53e00000000000000004160e53b2045c3bb000000000000803f0000803f0000803f0000803f00005c3f0000a53e0000000000000000da874f3c5c1db43a000000000000803f0000803f0000803f0000803f0000743f0000803e0000000000000000f1609e3c5c1db43a000000000000803f0000803f0000803f0000803f00007e3f0000803e0000000000000000f1609e3c2045c3bb000000000000803f0000803f0000803f0000803f00007e3f0000963e0000000000000000da874f3c2045c3bb000000000000803f0000803f0000803f0000803f0000743f0000963e0000000000000000fe1ba13c84f9723b000000000000803f0000803f0000803f0000803f0000703f0000803e000000000000000066f4b63c84f9723b000000000000803f0000803f0000803f0000803f0000743f0000803e000000000000000066f4b63cec58b8bb000000000000803f0000803f0000803f0000803f0000743f00009c3e0000000000000000fe1ba13cec58b8bb000000000000803f0000803f0000803f0000803f0000703f00009c3e000000000000000073afb93c5c1db43a000000000000803f0000803f0000803f0000803f0000743f0000803e0000000000000000774cf03c5c1db43a000000000000803f0000803f0000803f0000803f00007e3f0000803e0000000000000000774cf03c2045c3bb000000000000803f0000803f0000803f0000803f00007e3f0000963e000000000000000073afb93c2045c3bb000000000000803f0000803f0000803f0000803f0000743f0000963e00000000000000008407f33c5c1db43a000000000000803f0000803f0000803f0000803f0000663f00008f3e0000000000000000a3fe0d3d5c1db43a000000000000803f0000803f0000803f0000803f00806d3f00008f3e0000000000000000a3fe0d3dec58b8bb000000000000803f0000803f0000803f0000803f00806d3f0000a43e00000000000000008407f33cec58b8bb000000000000803f0000803f0000803f0000803f0000663f0000a43e0000000000000000
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -4082,6 +6922,113 @@ Mesh:
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
   m_MeshOptimized: 0
+--- !u!1 &318198443
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1315479071886288, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 318198444}
+  - component: {fileID: 318198448}
+  - component: {fileID: 318198447}
+  - component: {fileID: 318198446}
+  - component: {fileID: 318198445}
+  m_Layer: 0
+  m_Name: Thick Ribbon Renderer (colored lines)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &318198444
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4200987617497462, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 318198443}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0.0000023990867}
+  m_LocalPosition: {x: 0, y: 0.559, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 137824214}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &318198445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114913891726267932, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 318198443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a556b57af5586b4dbefb616d1d34b4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 11400000, guid: 5ea4c04050d38ab48855c675c78de715, type: 2}
+  clipTime: 29.266666
+--- !u!114 &318198446
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114625929350600168, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 318198443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41ee06f17d023954c9ea5105af0e174a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _ribbonMaterial: {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  _finalizedRibbonParent: {fileID: 181722600}
+  registerWithHistoryManager: 0
+--- !u!33 &318198447
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33343224749167078, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 318198443}
+  m_Mesh: {fileID: 0}
+--- !u!23 &318198448
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23385238376784644, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 318198443}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &320617826
 GameObject:
   m_ObjectHideFlags: 0
@@ -4464,6 +7411,163 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 344785561}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1001 &345963984
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 646267621}
+    m_Modifications:
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Name
+      value: Button Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &345963985 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_PrefabInternal: {fileID: 345963984}
+--- !u!1 &346890189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 346890190}
+  - component: {fileID: 346890193}
+  - component: {fileID: 346890192}
+  - component: {fileID: 346890191}
+  m_Layer: 0
+  m_Name: Today we are going to learn!
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &346890190
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 346890189}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &346890191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 346890189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76f3179ee3c21564a81795625cc0cabb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 960477181}
+  transitionState: {fileID: 0}
+  controller: {fileID: 1649983743}
+  markerName: PromptHand
+  condition: 1
+--- !u!114 &346890192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 346890189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+  _wrapMode: 2
+--- !u!114 &346890193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 346890189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: LoopAtMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: PromptHand
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1 &349081937
 GameObject:
   m_ObjectHideFlags: 0
@@ -4536,6 +7640,185 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 349081937}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &351986685
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1315479071886288, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 351986686}
+  - component: {fileID: 351986690}
+  - component: {fileID: 351986689}
+  - component: {fileID: 351986688}
+  - component: {fileID: 351986687}
+  m_Layer: 0
+  m_Name: Thick Ribbon Renderer (thic lines)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &351986686
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4200987617497462, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 351986685}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0.0000023990867}
+  m_LocalPosition: {x: 0, y: 0.559, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 137824214}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &351986687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114913891726267932, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 351986685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a556b57af5586b4dbefb616d1d34b4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 11400000, guid: 728329afc69970d418fa9fae9581b61b, type: 2}
+  clipTime: 29.266666
+--- !u!114 &351986688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114625929350600168, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 351986685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41ee06f17d023954c9ea5105af0e174a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _ribbonMaterial: {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  _finalizedRibbonParent: {fileID: 181722600}
+  registerWithHistoryManager: 0
+--- !u!33 &351986689
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33343224749167078, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 351986685}
+  m_Mesh: {fileID: 0}
+--- !u!23 &351986690
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23385238376784644, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 351986685}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &358618570
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 358618571}
+  - component: {fileID: 358618573}
+  - component: {fileID: 358618572}
+  m_Layer: 0
+  m_Name: Capsule (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &358618571
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 358618570}
+  m_LocalRotation: {x: 0.63698936, y: 0.23173064, z: -0.265427, w: 0.6856341}
+  m_LocalPosition: {x: 0.0121, y: 0.0107, z: -0.015}
+  m_LocalScale: {x: 0.005693968, y: 0.015588389, z: 0.005693966}
+  m_Children: []
+  m_Father: {fileID: 47246601}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 85.204, y: -14.110001, z: -55.311}
+--- !u!23 &358618572
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 358618570}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &358618573
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 358618570}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &360758304
 GameObject:
   m_ObjectHideFlags: 0
@@ -4565,6 +7848,141 @@ Transform:
   m_Father: {fileID: 886738118}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &361661855
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1748073865432018, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 361661856}
+  - component: {fileID: 361661858}
+  - component: {fileID: 361661857}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &361661856
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4368921068266860, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 361661855}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.018439703, y: 0.54261047, z: 0.2273914}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1025233048}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &361661857
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23093280790796154, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 361661855}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &361661858
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33846632685622160, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 361661855}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &364573459
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010310728758, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 364573460}
+  m_Layer: 5
+  m_Name: Wearable Brush Anchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &364573460
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000013067875132, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 364573459}
+  m_LocalRotation: {x: -0.6290648, y: -0.053939715, z: -0.039413672, w: -0.77447695}
+  m_LocalPosition: {x: -0.0814, y: 0.0022, z: -0.0169}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1429124829}
+  m_Father: {fileID: 1372450353}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 104.061005, y: -146.556, z: -147.789}
+--- !u!1 &368390648
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 368390649}
+  m_Layer: 0
+  m_Name: Brush Controls Wearable Root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &368390649
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 368390648}
+  m_LocalRotation: {x: -0.0025489037, y: 0.010939803, z: 0.10160603, w: 0.99476135}
+  m_LocalPosition: {x: 5.66, y: 1.52, z: -0.78}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1529262421}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -0.41300002, y: 1.182, z: 11.38}
 --- !u!1 &369385633
 GameObject:
   m_ObjectHideFlags: 0
@@ -4681,6 +8099,78 @@ MonoBehaviour:
   scaleLastFingerBone: 0
   modelFingerPointing: {x: 1, y: 0, z: 0}
   modelPalmFacing: {x: 0, y: -1, z: 0}
+--- !u!1 &371309392
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 371309393}
+  - component: {fileID: 371309395}
+  - component: {fileID: 371309394}
+  m_Layer: 5
+  m_Name: Appear Explosion Object
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &371309393
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 371309392}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 230986567}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &371309394
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 371309392}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &371309395
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 371309392}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1001 &374000320
 Prefab:
   m_ObjectHideFlags: 0
@@ -4718,6 +8208,10 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
       propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: _showArm
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -5112,6 +8606,140 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 397192579}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &398019396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 398019397}
+  - component: {fileID: 398019398}
+  m_Layer: 0
+  m_Name: Palm Direction Detector L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &398019397
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 398019396}
+  m_LocalRotation: {x: 0.000000014901161, y: 0.15038373, z: -0.25523615, w: -0.95511216}
+  m_LocalPosition: {x: -0.4202494, y: -0.11230394, z: -0.0661689}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1046230652}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &398019398
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 398019396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c057ae8396c1146c98a146b81dcc5870, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  OnActivate:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  OnDeactivate:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  Period: 0.1
+  HandModel: {fileID: 923751379}
+  PointingType: 3
+  PointingDirection: {x: 0, y: 0, z: 1}
+  TargetObject: {fileID: 1400439764}
+  OnAngle: 45
+  OffAngle: 55
+  ShowGizmos: 0
+--- !u!1 &402761981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1968612802118056, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 402761982}
+  - component: {fileID: 402761984}
+  - component: {fileID: 402761983}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &402761982
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4325553879825746, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 402761981}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.022431377, y: 0.46092647, z: 0.36937797}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1172146390}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &402761983
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23546258146111734, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 402761981}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &402761984
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33644294037164348, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 402761981}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &403491180
 GameObject:
   m_ObjectHideFlags: 0
@@ -5203,6 +8831,82 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 403491180}
   m_Mesh: {fileID: 0}
+--- !u!1 &415947740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1206271124574824, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 415947741}
+  - component: {fileID: 415947743}
+  - component: {fileID: 415947742}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &415947741
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4200641660935686, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 415947740}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.06946927, y: 0.46161753, z: 0.23306789}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1064702619}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &415947742
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23630814441398804, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 415947740}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &415947743
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33016726276085764, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 415947740}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1001 &421014702
 Prefab:
   m_ObjectHideFlags: 0
@@ -5274,6 +8978,36 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad,
     type: 3}
   m_PrefabInternal: {fileID: 421014702}
+--- !u!1 &427834431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000013079249492, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 427834432}
+  m_Layer: 0
+  m_Name: Index UI Activator R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &427834432
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000014090360156, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 427834431}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0, y: 0.0008, z: 0.0041}
+  m_LocalScale: {x: 0.00770639, y: 0.0077063865, z: 0.0077063898}
+  m_Children: []
+  m_Father: {fileID: 45922386}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &429624729
 GameObject:
   m_ObjectHideFlags: 0
@@ -5377,64 +9111,479 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
---- !u!1 &435133761
+--- !u!1 &430827530
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1891877802093360, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 430827531}
+  - component: {fileID: 430827533}
+  - component: {fileID: 430827532}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &430827531
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4903894340538030, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 430827530}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.0026242884, y: 0.507657, z: -0.11423433}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 103874079}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &430827532
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23366301356863414, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 430827530}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &430827533
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33416699022691116, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 430827530}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &435959904
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1981546297891286, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 435959905}
+  - component: {fileID: 435959907}
+  - component: {fileID: 435959906}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &435959905
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4888145891854092, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 435959904}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.034955904, y: 0.062334213, z: -0.05660713}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1851737852}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &435959906
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23296418216822734, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 435959904}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &435959907
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33135286502649134, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 435959904}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &440737277
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011918253960, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 440737278}
+  m_Layer: 0
+  m_Name: Pinch Detector R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &440737278
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012182625992, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 440737277}
+  m_LocalRotation: {x: -0.8367229, y: 0.35278293, z: -0.3889267, w: 0.1554831}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 537749379}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 172.045, y: -44.432007, z: 0}
+--- !u!1 &441987437
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 435133762}
-  - component: {fileID: 435133763}
+  - component: {fileID: 441987438}
+  - component: {fileID: 441987440}
+  - component: {fileID: 441987439}
   m_Layer: 0
-  m_Name: Palm Direction Detector L
+  m_Name: Waving
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &435133762
+--- !u!4 &441987438
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 435133761}
+  m_GameObject: {fileID: 441987437}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 1046230652}
-  m_RootOrder: 1
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &435133763
+--- !u!114 &441987439
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 435133761}
+  m_GameObject: {fileID: 441987437}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c057ae8396c1146c98a146b81dcc5870, type: 3}
+  m_Script: {fileID: 11500000, guid: 758c0876ee0e3d04aa2a2c0f389cd3d5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  OnActivate:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  OnDeactivate:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  Period: 0.1
-  HandModel: {fileID: 923751379}
-  PointingType: 3
-  PointingDirection: {x: 0, y: 0, z: 1}
-  TargetObject: {fileID: 1400439764}
-  OnAngle: 45
-  OffAngle: 55
-  ShowGizmos: 0
+  destination: {fileID: 1719081241}
+  transitionState: {fileID: 0}
+  waveDirection: {x: 0, y: 0, z: 1}
+  waveTime: 1
+--- !u!114 &441987440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 441987437}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 8011ee1000fb4684eaa2b53683c9c9b3, type: 2}
+  _wrapMode: 1
+--- !u!1 &443618196
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 443618197}
+  - component: {fileID: 443618199}
+  - component: {fileID: 443618198}
+  m_Layer: 0
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &443618197
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 443618196}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0.0127, z: 0.0162}
+  m_LocalScale: {x: 0.010088271, y: 0.010088269, z: 0.010088269}
+  m_Children: []
+  m_Father: {fileID: 623977230}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!23 &443618198
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 443618196}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &443618199
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 443618196}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &445224929
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011256710288, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 445224930}
+  - component: {fileID: 445224931}
+  m_Layer: 0
+  m_Name: Index
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &445224930
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000013427397758, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 445224929}
+  m_LocalRotation: {x: -0.8101422, y: -0.049423337, z: -0.19851074, w: 0.54938185}
+  m_LocalPosition: {x: 0.26697364, y: 1.5602217, z: 1.2093616}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1510378715}
+  - {fileID: 563168409}
+  - {fileID: 799494172}
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &445224931
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 445224929}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 243000011195632352, guid: 43de2443e9a4ff54e842fdf9d3168906,
+    type: 2}
+  m_audioClip: {fileID: 8300000, guid: 6f5a650c3de44044f98886081b52cb38, type: 3}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 1
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+--- !u!1 &446111047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1352994391108750, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 446111048}
+  m_Layer: 0
+  m_Name: Wearable Root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &446111048
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4513784704483600, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 446111047}
+  m_LocalRotation: {x: 0.70615155, y: 0.043537248, z: -0.04348978, w: 0.70538163}
+  m_LocalPosition: {x: -1.97, y: 0.932, z: 0.563}
+  m_LocalScale: {x: 0.40706515, y: 0.40706453, z: 0.4070645}
+  m_Children: []
+  m_Father: {fileID: 63207537}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &448974147
 Prefab:
   m_ObjectHideFlags: 0
@@ -5489,6 +9638,36 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a130c5a83e325b743a07a8c4b29d7633, type: 3}
   m_IsPrefabParent: 0
+--- !u!1 &451462309
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010244318134, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 451462310}
+  m_Layer: 0
+  m_Name: GrabPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &451462310
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012042752062, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 451462309}
+  m_LocalRotation: {x: -0.12019451, y: 0.73785365, z: 0.6504648, w: 0.13424185}
+  m_LocalPosition: {x: -0.16474323, y: 0.062239647, z: 0.25752527}
+  m_LocalScale: {x: 0.9999999, y: 1.0000001, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: -360, z: 0}
 --- !u!1 &453866243
 GameObject:
   m_ObjectHideFlags: 0
@@ -5897,6 +10076,37 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &472929501
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 472929502}
+  m_Layer: 0
+  m_Name: Dynamic Cursor Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &472929502
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 472929501}
+  m_LocalRotation: {x: -0.25171152, y: 0.000000006519259, z: 0.0000000027939682, w: 0.96780235}
+  m_LocalPosition: {x: -1.51, y: 0.91, z: 8.56}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 570454094}
+  - {fileID: 1449351597}
+  - {fileID: 619221906}
+  m_Father: {fileID: 150231449}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: -29.158, y: 0, z: 0}
 --- !u!1 &473414028
 GameObject:
   m_ObjectHideFlags: 0
@@ -6083,6 +10293,38 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &480798552
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1613402464799590, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 480798553}
+  m_Layer: 0
+  m_Name: Color Swatch (21)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &480798553
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4730121298372838, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 480798552}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -1.2930794, y: 2.6, z: -0.78}
+  m_LocalScale: {x: 0.38721135, y: 0.38720983, z: 0.38721022}
+  m_Children:
+  - {fileID: 559325172}
+  - {fileID: 1591171698}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 22
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &480832574
 Prefab:
   m_ObjectHideFlags: 0
@@ -6212,6 +10454,36 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 480832574}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &483099617
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010309604832, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 483099618}
+  m_Layer: 0
+  m_Name: Arm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &483099618
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000014069365038, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 483099617}
+  m_LocalRotation: {x: -0.8627296, y: -0.075480185, z: -0.12941155, w: 0.48296273}
+  m_LocalPosition: {x: 0.18795614, y: 1.3190794, z: 1.3226138}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &484577933
 GameObject:
   m_ObjectHideFlags: 0
@@ -6300,6 +10572,34 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &487857267
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 487857268}
+  m_Layer: 0
+  m_Name: Palm Direction Detector R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &487857268
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 487857267}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1948795073}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &490758891
 GameObject:
   m_ObjectHideFlags: 0
@@ -6504,6 +10804,145 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 491766521}
+--- !u!1 &495279504
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1272931191924952, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 495279505}
+  - component: {fileID: 495279507}
+  - component: {fileID: 495279506}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &495279505
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4724594899016938, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 495279504}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.040646527, y: 0.27647516, z: -0.019967409}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 266988905}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &495279506
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23419749178019992, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 495279504}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &495279507
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33485904974592886, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 495279504}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &504093781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1775258195079372, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 504093782}
+  m_Layer: 0
+  m_Name: Color Swatch (18)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &504093782
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4781504630071136, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 504093781}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 1.260107, y: 2.6, z: -0.78}
+  m_LocalScale: {x: 0.3872106, y: 0.38720962, z: 0.38720992}
+  m_Children:
+  - {fileID: 1374220061}
+  - {fileID: 129176816}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &505945871
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 505945872}
+  m_Layer: 0
+  m_Name: Undo Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &505945872
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 505945871}
+  m_LocalRotation: {x: 0.00000056624407, y: 1, z: 0.00000032433303, w: 0.000000037252963}
+  m_LocalPosition: {x: -1.7666689, y: 0, z: -0.8533313}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2029453417}
+  - {fileID: 2082590617}
+  - {fileID: 884648090}
+  m_Father: {fileID: 616489409}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &507335199
 GameObject:
   m_ObjectHideFlags: 0
@@ -6532,6 +10971,36 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 15
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &508224416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1726079354297982, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 508224417}
+  m_Layer: 0
+  m_Name: Box Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &508224417
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4600655259665150, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 508224416}
+  m_LocalRotation: {x: -0.0037646287, y: 0.7070967, z: 0.7070969, w: 0.0037643986}
+  m_LocalPosition: {x: 0.06, y: -0.19, z: -0.8}
+  m_LocalScale: {x: 6.1683545, y: 5.1102014, z: 0.34657586}
+  m_Children: []
+  m_Father: {fileID: 887154784}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: -89.961006, y: 0, z: -180.592}
 --- !u!1 &519855476
 GameObject:
   m_ObjectHideFlags: 0
@@ -6636,6 +11105,204 @@ SkinnedMeshRenderer:
     m_Center: {x: -0.07362159, y: -0.0016784072, z: -0.008478552}
     m_Extent: {x: 0.10426653, y: 0.044362344, z: 0.08608112}
   m_DirtyAABB: 0
+--- !u!1 &530424313
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1769170623856830, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 530424314}
+  - component: {fileID: 530424316}
+  - component: {fileID: 530424315}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &530424314
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4597454690860164, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 530424313}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.12484499, y: -0.07359967, z: 0.4042823}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 66919111}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &530424315
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23140791219578416, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 530424313}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &530424316
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33470741914767896, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 530424313}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &532545419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 532545420}
+  - component: {fileID: 532545422}
+  - component: {fileID: 532545421}
+  m_Layer: 0
+  m_Name: Here is how you do it
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &532545420
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 532545419}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &532545421
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 532545419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76f3179ee3c21564a81795625cc0cabb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1824284224}
+  transitionState: {fileID: 0}
+  controller: {fileID: 1649983743}
+  markerName: WaitForColor
+  condition: 1
+--- !u!114 &532545422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 532545419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: e1983c6ba9fe05c48bc22a575c41c0d1, type: 2}
+  _wrapMode: 2
+--- !u!1 &537749378
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011043660800, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 537749379}
+  m_Layer: 0
+  m_Name: PinchPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &537749379
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012862377392, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 537749378}
+  m_LocalRotation: {x: 0.19979398, y: 0.5698164, z: 0.5219491, w: -0.6024623}
+  m_LocalPosition: {x: -0.27325857, y: 1.5366824, z: 1.2494842}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 440737278}
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &540152222
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010310728758, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 540152223}
+  m_Layer: 5
+  m_Name: Wearable Color Anchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &540152223
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000013067875132, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 540152222}
+  m_LocalRotation: {x: -0.7265919, y: -0.044546854, z: -0.021949926, w: -0.6852723}
+  m_LocalPosition: {x: -0.0861, y: 0.0063, z: 0.044}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 561677406}
+  m_Father: {fileID: 1372450353}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 96.36899, y: -57.096985, z: -59.00598}
 --- !u!1 &545424298
 GameObject:
   m_ObjectHideFlags: 0
@@ -6676,6 +11343,38 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &552670152
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1249230495180172, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 552670153}
+  m_Layer: 0
+  m_Name: Color Swatch (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &552670153
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4500313507348888, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 552670152}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 2.1124544, y: 1.11, z: -0.64}
+  m_LocalScale: {x: 0.38721025, y: 0.38720945, z: 0.38720974}
+  m_Children:
+  - {fileID: 1376903707}
+  - {fileID: 1417739366}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &557310474
 GameObject:
   m_ObjectHideFlags: 0
@@ -6705,6 +11404,188 @@ Transform:
   m_Children: []
   m_Father: {fileID: 729865844}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &559325171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1331908991782064, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 559325172}
+  - component: {fileID: 559325174}
+  - component: {fileID: 559325173}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &559325172
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4608354907342090, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 559325171}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.16050354, y: -0.097754486, z: 0.462313}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 480798553}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &559325173
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23623265696242712, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 559325171}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &559325174
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33064859351409044, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 559325171}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &561677405
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000014286133064, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 561677406}
+  - component: {fileID: 561677408}
+  - component: {fileID: 561677407}
+  m_Layer: 0
+  m_Name: Attachment Ring
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &561677406
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012530090064, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 561677405}
+  m_LocalRotation: {x: -0, y: -0, z: -9.313227e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 2.0256948, y: 2.0256953, z: 2.0256953}
+  m_Children: []
+  m_Father: {fileID: 540152223}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -185.31, y: 0, z: 180}
+--- !u!23 &561677407
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23000010185471664, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 561677405}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &561677408
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33000012982707688, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 561677405}
+  m_Mesh: {fileID: 4300000, guid: bb552b845e1247e4b96d83b9c9bd0207, type: 3}
+--- !u!1 &563168408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010682427734, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 563168409}
+  m_Layer: 0
+  m_Name: Index Sphere Body L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &563168409
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012354608040, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 563168408}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.00132, z: 0.00269}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 445224930}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &568333085
 GameObject:
@@ -6759,6 +11640,72 @@ MonoBehaviour:
   _ribbonCircleMaterial: {fileID: 2100000, guid: 61afe0ccec8b7184393fd43d3e92a44f,
     type: 2}
   _ribbonCirclePosition: {x: 0, y: 0.005, z: 0}
+--- !u!1001 &570454093
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 472929502}
+    m_Modifications:
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Name
+      value: Button Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &570454094 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_PrefabInternal: {fileID: 570454093}
 --- !u!1 &570599649
 GameObject:
   m_ObjectHideFlags: 0
@@ -6811,7 +11758,7 @@ MonoBehaviour:
   OnRelease:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2085845412}
+      - m_Target: {fileID: 0}
         m_MethodName: SetCursorFollowRigid
         m_Mode: 1
         m_Arguments:
@@ -6903,6 +11850,79 @@ Transform:
   m_Father: {fileID: 622246578}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &572014664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 572014665}
+  - component: {fileID: 572014667}
+  - component: {fileID: 572014666}
+  m_Layer: 5
+  m_Name: Marble
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &572014665
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 572014664}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1289417879}
+  m_Father: {fileID: 94550650}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &572014666
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 572014664}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 28eefa2b18c4cac49be691746e981da5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &572014667
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 572014664}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &573169331
 GameObject:
   m_ObjectHideFlags: 0
@@ -6942,7 +11962,7 @@ GameObject:
   - component: {fileID: 573826044}
   - component: {fileID: 573826043}
   m_Layer: 0
-  m_Name: Leap Rig
+  m_Name: Player Rig
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -6982,9 +12002,7 @@ Transform:
   - {fileID: 1400439764}
   - {fileID: 270074878}
   - {fileID: 648100116}
-  - {fileID: 631514233}
   - {fileID: 75253546}
-  - {fileID: 1913432935}
   - {fileID: 757562292}
   - {fileID: 149610049}
   - {fileID: 2069956111}
@@ -7127,7 +12145,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _tipMeshRenderer: {fileID: 580812671}
   _startingColor: {r: 0.1137255, g: 0.27058825, b: 0.64705884, a: 1}
-  _cursor: {fileID: 2085845412}
+  _cursor: {fileID: 0}
   _colorMarbleMaterial: {fileID: 2100000, guid: 043e6d1c9a26f5f46b53a5cd101324db,
     type: 2}
   _transparentMarbleMaterial: {fileID: 2100000, guid: 934c4f9882e1fa74aab1b10cb36aef08,
@@ -7214,6 +12232,80 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad,
     type: 3}
   m_PrefabInternal: {fileID: 580979319}
+--- !u!1 &582206189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 582206190}
+  - component: {fileID: 582206192}
+  - component: {fileID: 582206191}
+  m_Layer: 0
+  m_Name: Ok now we can get started
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &582206190
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 582206189}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &582206191
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 582206189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1acce328dc31db144bf7f60e252765d3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 346890189}
+  transitionState: {fileID: 0}
+  delay: 2
+--- !u!114 &582206192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 582206189}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: SetText
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: Ok now we can get started!
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1 &589708811
 GameObject:
   m_ObjectHideFlags: 0
@@ -7316,6 +12408,37 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &606411736
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010148702922, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 606411737}
+  m_Layer: 0
+  m_Name: PinchPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &606411737
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000010403175552, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 606411736}
+  m_LocalRotation: {x: -0.56981355, y: -0.19979648, z: -0.60246503, w: 0.5219481}
+  m_LocalPosition: {x: 0.27324647, y: 1.5366824, z: 1.2494867}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 255535908}
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &616482364
 GameObject:
   m_ObjectHideFlags: 0
@@ -7396,6 +12519,125 @@ Transform:
   m_Father: {fileID: 1255518562}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
+--- !u!1 &616489408
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 616489409}
+  m_Layer: 0
+  m_Name: Brush Controls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &616489409
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 616489408}
+  m_LocalRotation: {x: -0.002548814, y: 0.010939813, z: 0.10160602, w: 0.99476135}
+  m_LocalPosition: {x: 5.6600027, y: 1.5200006, z: -0.7800063}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1159817118}
+  - {fileID: 505945872}
+  - {fileID: 1536610378}
+  m_Father: {fileID: 1529262421}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &619221905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 619221906}
+  - component: {fileID: 619221908}
+  - component: {fileID: 619221907}
+  m_Layer: 0
+  m_Name: Button Icon (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &619221906
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 619221905}
+  m_LocalRotation: {x: 8.84796e-10, y: 0.7071068, z: -0.7071067, w: -0.0000000043860373}
+  m_LocalPosition: {x: 0, y: 0.4999964, z: 0}
+  m_LocalScale: {x: 0.10000031, y: 0.099999964, z: 0.10000021}
+  m_Children: []
+  m_Father: {fileID: 472929502}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 90, y: 180, z: 0}
+--- !u!102 &619221907
+TextMesh:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 619221905}
+  m_Text: 'Dynamic
+
+    Cursor'
+  m_OffsetZ: 0
+  m_CharacterSize: 1
+  m_LineSpacing: 1
+  m_Anchor: 4
+  m_Alignment: 1
+  m_TabSize: 4
+  m_FontSize: 50
+  m_FontStyle: 0
+  m_RichText: 1
+  m_Font: {fileID: 12800000, guid: cd2b86fdeb787f84698ee40d32de9350, type: 3}
+  m_Color:
+    serializedVersion: 2
+    rgba: 4287072135
+--- !u!23 &619221908
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 619221905}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 89e1f0dde257b3c45a5f0b5574299f85, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1001 &621030490
 Prefab:
   m_ObjectHideFlags: 0
@@ -7623,104 +12865,169 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
---- !u!1 &631514232
+--- !u!1 &623977229
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 631514233}
-  - component: {fileID: 631514234}
+  - component: {fileID: 623977230}
   m_Layer: 0
-  m_Name: Pinch Painting LH
+  m_Name: PinkyDistalJoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &631514233
+--- !u!4 &623977230
 Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 631514232}
+  m_GameObject: {fileID: 623977229}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.000000010244548, y: 0.000000096857505, z: 0.018110069}
+  m_LocalScale: {x: 0.48969322, y: 0.48969302, z: 0.489693}
+  m_Children:
+  - {fileID: 443618197}
+  m_Father: {fileID: 1373595205}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &636459939
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1270290931676350, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 636459940}
+  - component: {fileID: 636459942}
+  - component: {fileID: 636459941}
+  m_Layer: 0
+  m_Name: Sphere R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &636459940
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4702762467585894, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 636459939}
+  m_LocalRotation: {x: -4.3297806e-17, y: 0.7071068, z: 0.7071068, w: -4.3297806e-17}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 655833091}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &636459941
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23722376907340318, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 636459939}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: ea35c962ec786d346b0f4c257dd3e9ee, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &636459942
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33740636978112938, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 636459939}
+  m_Mesh: {fileID: 4300000, guid: 0a969de86108bb448bd93c6901920346, type: 3}
+--- !u!1 &640536046
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 640536047}
+  - component: {fileID: 640536049}
+  - component: {fileID: 640536048}
+  m_Layer: 0
+  m_Name: This is how you do the undo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &640536047
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 640536046}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 573826044}
-  m_RootOrder: 3
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 21
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &631514234
+--- !u!114 &640536048
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 631514232}
+  m_GameObject: {fileID: 640536046}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ba90156d1d42974a88d6770da26c302, type: 3}
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _paintCursor: {fileID: 2085845412}
-  _wearableManager: {fileID: 663620331}
-  _historyManager: {fileID: 2069956110}
-  _ribbonParentObject: {fileID: 1991659427}
-  _ribbonMaterial: {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
-  _ribbonIO: {fileID: 1385638904}
-  _colorFilter: {fileID: 580812672}
-  _thicknessFilter: {fileID: 149610048}
-  _thicknessCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1.0005364
-      inSlope: Infinity
-      outSlope: -0.0025489503
-      tangentMode: 69
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.08231167
-      value: 1.0003266
-      inSlope: 0.011180659
-      outSlope: -0.00000041376688
-      tangentMode: 1
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 0.99527794
-      value: -0.000000059604645
-      inSlope: -2.307289
-      outSlope: -1.3633035
-      tangentMode: 1
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 0
-  interactionHand: {fileID: 998367418}
-  _beginEffect:
-    _clips:
-    - {fileID: 8300000, guid: f54329085cacc4b4f9d7f9bbb7e5ac6a, type: 3}
-    - {fileID: 8300000, guid: 35b37b9ce3d97924980fc2dc98d13f6b, type: 3}
-    - {fileID: 8300000, guid: 13b9a4adfd6987c45875dc78da9f7bad, type: 3}
-    _mixerGroup: {fileID: 243000011195632352, guid: 43de2443e9a4ff54e842fdf9d3168906,
-      type: 2}
-    _volume: 0.45
-    _pitchVariance: 0.2
-    _pitchCenter: 0.9
-  _soundEffectSource: {fileID: 157615678}
-  _volumeScale: 0.5
-  _maxEffectSpeed: 5
-  _pitchRange: {x: 0.8, y: 1.2}
-  _smoothingDelay: 0.03
-  drawTime: 0
+  destination: {fileID: 1737902597}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &640536049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 640536046}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 1b71ced2c6ac3394db0545294040bf48, type: 2}
+  _wrapMode: 2
 --- !u!1001 &642615116
 Prefab:
   m_ObjectHideFlags: 0
@@ -7916,6 +13223,37 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 645049392}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &646267620
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 646267621}
+  m_Layer: 0
+  m_Name: Rigid Cursor Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &646267621
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 646267620}
+  m_LocalRotation: {x: -0.25171152, y: 0.000000006519259, z: 0.0000000027939682, w: 0.96780235}
+  m_LocalPosition: {x: 1.57, y: 0.91, z: 8.56}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 345963985}
+  - {fileID: 1130966993}
+  - {fileID: 2081700212}
+  m_Father: {fileID: 150231449}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: -29.158, y: 0, z: 0}
 --- !u!1 &648100113
 GameObject:
   m_ObjectHideFlags: 0
@@ -7977,6 +13315,34 @@ Transform:
   m_Father: {fileID: 573826044}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &650284664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 650284665}
+  m_Layer: 0
+  m_Name: Pinch Painting LH
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &650284665
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 650284664}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1311336093}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &650723357
 GameObject:
   m_ObjectHideFlags: 0
@@ -8008,6 +13374,144 @@ Transform:
   m_Father: {fileID: 575289177}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &652610719
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1812363002875954, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 652610720}
+  m_Layer: 0
+  m_Name: Box Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &652610720
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4127344882956374, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652610719}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.06, y: 0.03, z: -0.16}
+  m_LocalScale: {x: 5.1319523, y: 0.2857803, z: 5.1319523}
+  m_Children: []
+  m_Father: {fileID: 1738942289}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &655833090
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1574850176543768, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 655833091}
+  m_Layer: 0
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &655833091
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4711355659191914, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 655833090}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0.5}
+  m_Children:
+  - {fileID: 129030013}
+  - {fileID: 636459940}
+  m_Father: {fileID: 892674014}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &658031627
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1762547648964476, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 658031628}
+  - component: {fileID: 658031630}
+  - component: {fileID: 658031629}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &658031628
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4918439615825910, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 658031627}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.1479937, y: -0.0011857144, z: 0.4124145}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 817339876}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &658031629
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23810244055376176, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 658031627}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &658031630
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33961025181936028, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 658031627}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &658501597
 GameObject:
   m_ObjectHideFlags: 0
@@ -8285,7 +13789,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _centerEyeAnchor: {fileID: 1400439764}
   _leftHand: {fileID: 923751379}
-  _leftPalmFacingDetector: {fileID: 435133763}
+  _leftPalmFacingDetector: {fileID: 398019398}
   _rightHand: {fileID: 729865845}
   _rightPalmFacingDetector: {fileID: 990454467}
   _pinchGrabDistance: 0.05
@@ -8342,6 +13846,78 @@ Transform:
   m_Father: {fileID: 490758892}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &667667483
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 667667484}
+  - component: {fileID: 667667486}
+  - component: {fileID: 667667485}
+  m_Layer: 0
+  m_Name: Capsule
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &667667484
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 667667483}
+  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: -0.016845588, y: -0.013245917, z: -0.016845575}
+  m_Children: []
+  m_Father: {fileID: 233744293}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+--- !u!23 &667667485
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 667667483}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &667667486
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 667667483}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &673997412
 GameObject:
   m_ObjectHideFlags: 0
@@ -8416,6 +13992,78 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 673997412}
+--- !u!1 &676920903
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 676920904}
+  - component: {fileID: 676920906}
+  - component: {fileID: 676920905}
+  m_Layer: 0
+  m_Name: Handle Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &676920904
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 676920903}
+  m_LocalRotation: {x: -0.0000000027759481, y: -0.7071068, z: 0.7071068, w: 0.0000000027759481}
+  m_LocalPosition: {x: 0, y: 0.3014874, z: 0}
+  m_LocalScale: {x: 1.6936619, y: 1.69366, z: 1.6936605}
+  m_Children: []
+  m_Father: {fileID: 809709092}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 180}
+--- !u!23 &676920905
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 676920903}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: ee3cc47f6f35c064e819c8049e1cd56b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &676920906
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 676920903}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &678408570
 GameObject:
   m_ObjectHideFlags: 0
@@ -8474,6 +14122,81 @@ MonoBehaviour:
   scaleLastFingerBone: 0
   modelFingerPointing: {x: -1, y: 0, z: 0}
   modelPalmFacing: {x: 0, y: 1, z: 0}
+--- !u!1 &693536396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 693536397}
+  - component: {fileID: 693536399}
+  - component: {fileID: 693536398}
+  m_Layer: 0
+  m_Name: Give thumbs up to continue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &693536397
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 693536396}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &693536398
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 693536396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 715153d525c322e47890cc24adb976b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1828041192}
+  transitionState: {fileID: 222778846}
+  withinAngle: 70
+  forDuration: 1
+--- !u!114 &693536399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 693536396}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: SetText
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: Give me the thumbs up when you are ready to move on!
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!21 &705672457
 Material:
   serializedVersion: 6
@@ -8666,6 +14389,158 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &719820616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1354133697137550, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 719820617}
+  - component: {fileID: 719820619}
+  - component: {fileID: 719820618}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &719820617
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4231041832962558, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 719820616}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.21296012, y: 0.14360079, z: 0.51346797}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 158968539}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &719820618
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23004115189947602, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 719820616}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &719820619
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33628184880182198, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 719820616}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &721232894
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1658822490466862, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 721232895}
+  - component: {fileID: 721232897}
+  - component: {fileID: 721232896}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &721232895
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4348830706527276, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 721232894}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: -0.025913673, y: 0.37410188, z: -0.04880102}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1341977917}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &721232896
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23066221758860374, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 721232894}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &721232897
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33853206469540326, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 721232894}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &729865843
 GameObject:
   m_ObjectHideFlags: 0
@@ -8758,6 +14633,11 @@ Prefab:
         type: 2}
       propertyPath: soundEffect._clips.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4000013939052844, guid: c915520bed265f24c95aebc38ee51557, type: 2}
       propertyPath: m_LocalPosition.x
@@ -8853,6 +14733,31 @@ Prefab:
       value: 
       objectReference: {fileID: 243000011340830754, guid: 43de2443e9a4ff54e842fdf9d3168906,
         type: 2}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1840705451}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: NotifyColorPalleteTouched
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c915520bed265f24c95aebc38ee51557, type: 2}
   m_IsPrefabParent: 0
@@ -8903,6 +14808,76 @@ Transform:
   m_Father: {fileID: 1037689706}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &735067417
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1455894659}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Surface
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &735067418 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 735067417}
 --- !u!1 &735183714
 GameObject:
   m_ObjectHideFlags: 0
@@ -8977,6 +14952,82 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 735183714}
+--- !u!1 &736830609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1065614928369748, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 736830610}
+  - component: {fileID: 736830612}
+  - component: {fileID: 736830611}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &736830610
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4982978239306220, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 736830609}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.03237412, y: 0.7393193, z: -0.016177807}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1513574475}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &736830611
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23158684062495190, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 736830609}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &736830612
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33009579074640202, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 736830609}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &741863752
 GameObject:
   m_ObjectHideFlags: 0
@@ -9092,6 +15143,38 @@ MonoBehaviour:
   eligibleIndexTipColors:
   - {fileID: 1102714711}
   enabledWhenReceivingColor: {fileID: 1321134213}
+--- !u!1 &752051448
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1654882574378686, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 752051449}
+  m_Layer: 0
+  m_Name: Color Swatch (22)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &752051449
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4211676815878718, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 752051448}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -2.1454277, y: 2.6, z: -0.78}
+  m_LocalScale: {x: 0.38721135, y: 0.38720983, z: 0.38721022}
+  m_Children:
+  - {fileID: 1329487791}
+  - {fileID: 285073529}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &757562290
 GameObject:
   m_ObjectHideFlags: 0
@@ -9154,7 +15237,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 573826044}
-  m_RootOrder: 6
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &763797978
 GameObject:
@@ -9186,6 +15269,78 @@ Transform:
   m_Father: {fileID: 1628291522}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &765684905
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 765684906}
+  - component: {fileID: 765684908}
+  - component: {fileID: 765684907}
+  m_Layer: 0
+  m_Name: Button Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &765684906
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 765684905}
+  m_LocalRotation: {x: -0.0000000027759197, y: -0.70710677, z: 0.7071069, w: 0.000000032578296}
+  m_LocalPosition: {x: 0, y: 0.4, z: 0}
+  m_LocalScale: {x: 1.3806864, y: 1.3806852, z: 1.3806857}
+  m_Children: []
+  m_Father: {fileID: 1536610378}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 180}
+--- !u!23 &765684907
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 765684905}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 36e48b09dc5e232479a215bc23ad93c1, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &765684908
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 765684905}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &767143169
 GameObject:
   m_ObjectHideFlags: 0
@@ -9215,6 +15370,76 @@ Transform:
   m_Father: {fileID: 1144605979}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &767898358
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1455894659}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 3300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &767898359 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 767898358}
 --- !u!1 &774728437
 GameObject:
   m_ObjectHideFlags: 0
@@ -9500,6 +15725,218 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &785999786
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1615942986735010, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 785999787}
+  - component: {fileID: 785999789}
+  - component: {fileID: 785999788}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &785999787
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4447839874508180, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 785999786}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.052613832, y: -0.08870116, z: 0.13054582}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 990536909}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &785999788
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23952029675165112, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 785999786}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &785999789
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33151205498036508, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 785999786}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &789337754
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010664807080, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 789337755}
+  m_Layer: 0
+  m_Name: Arm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &789337755
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012954238486, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 789337754}
+  m_LocalRotation: {x: 0.8627302, y: -0.075478025, z: -0.1294075, w: -0.48296311}
+  m_LocalPosition: {x: -0.18796891, y: 1.3190794, z: 1.3226119}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &789892009
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 789892010}
+  - component: {fileID: 789892012}
+  - component: {fileID: 789892011}
+  m_Layer: 0
+  m_Name: Try the pallete! (waiting)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &789892010
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 789892009}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 29
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &789892011
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 789892009}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1a7cb37f67ac5a542ba7599f71e1c82b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1637684299}
+  transitionState: {fileID: 0}
+  control: {fileID: 1840705451}
+--- !u!114 &789892012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 789892009}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: LoopAtMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: TryWidget
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+--- !u!1 &790923304
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1883551669005150, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 790923305}
+  m_Layer: 0
+  m_Name: Color Swatch (15)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &790923305
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4923314134404814, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 790923304}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -1.7057552, y: 1.86, z: -0.71}
+  m_LocalScale: {x: 0.38721097, y: 0.3872097, z: 0.38721007}
+  m_Children:
+  - {fileID: 1304375782}
+  - {fileID: 1191132583}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &791883846
 Prefab:
   m_ObjectHideFlags: 0
@@ -9688,6 +16125,178 @@ MonoBehaviour:
     _pitchCenter: 1
   _distancePerTick: 0.14
   tickCooldown: 6
+--- !u!1 &799494171
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000013079249492, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 799494172}
+  m_Layer: 0
+  m_Name: Index UI Activator L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &799494172
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000014090360156, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 799494171}
+  m_LocalRotation: {x: -0.024544781, y: -0.018738143, z: -0.017516142, w: 0.9993696}
+  m_LocalPosition: {x: 0.0005, y: 0.0017, z: 0.0038}
+  m_LocalScale: {x: 0.007706398, y: 0.007706394, z: 0.007706395}
+  m_Children: []
+  m_Father: {fileID: 445224930}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: -2.822, y: -2.038, z: -1.899}
+--- !u!1 &806411397
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1873895246647104, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 806411398}
+  - component: {fileID: 806411400}
+  - component: {fileID: 806411399}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &806411398
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4459144245247124, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 806411397}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.02856192, y: 0.48795506, z: 0.04018712}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1222972609}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &806411399
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23215054348733896, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 806411397}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &806411400
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33053812201559704, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 806411397}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1001 &809709091
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1159817118}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.5610056
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.10000404
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.0000005811452
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.00000029127108
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.000000052154054
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+      propertyPath: m_Name
+      value: Slider Handle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &809709092 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+  m_PrefabInternal: {fileID: 809709091}
 --- !u!1001 &810001412
 Prefab:
   m_ObjectHideFlags: 0
@@ -9817,6 +16426,38 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 810001412}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &817339875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1408545368697612, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 817339876}
+  m_Layer: 0
+  m_Name: Color Swatch (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &817339876
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4179062498703598, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 817339875}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 1.7036352, y: 0.38, z: -0.57}
+  m_LocalScale: {x: 0.38720986, y: 0.38720933, z: 0.38720956}
+  m_Children:
+  - {fileID: 1939255997}
+  - {fileID: 658031628}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &818829535
 GameObject:
   m_ObjectHideFlags: 0
@@ -9948,7 +16589,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 1584
-    _typelessdata: 1483c0bc5c1db43a000000000000803f0000803f0000803f0000803f0000c43d0000153f0000000000000000371792bc5c1db43a000000000000803f0000803f0000803f0000803f0000043e0000153f0000000000000000371792bc2045c3bb000000000000803f0000803f0000803f0000803f0000043e0000203f00000000000000001483c0bc2045c3bb000000000000803f0000803f0000803f0000803f0000c43d0000203f000000000000000044d294bc5c1db43a000000000000803f0000803f0000803f0000803f0000e83d0000f23e0000000000000000806a3cbc5c1db43a000000000000803f0000803f0000803f0000803f00001c3e0000f23e0000000000000000806a3cbc2045c3bb000000000000803f0000803f0000803f0000803f00001c3e0000043f000000000000000044d294bc2045c3bb000000000000803f0000803f0000803f0000803f0000e83d0000043f00000000000000009be041bce6971b3b000000000000803f0000803f0000803f0000803f0000ac3e0000843e0000000000000000f7fdd4bbe6971b3b000000000000803f0000803f0000803f0000803f0000bc3e0000843e0000000000000000f7fdd4bb2045c3bb000000000000803f0000803f0000803f0000803f0000bc3e00009d3e00000000000000009be041bc2045c3bb000000000000803f0000803f0000803f0000803f0000ac3e00009d3e00000000000000005fd6eabb8480a2bb000000000000803f0000803f0000803f0000803f0000e43d0000da3e0000000000000000f7fdd4bb8480a2bb000000000000803f0000803f0000803f0000803f0000ec3d0000da3e0000000000000000f7fdd4bbec58b8bb000000000000803f0000803f0000803f0000803f0000ec3d0000dc3e00000000000000005fd6eabbec58b8bb000000000000803f0000803f0000803f0000803f0000e43d0000dc3e0000000000000000af387bbb5c1db43a000000000000803f0000803f0000803f0000803f0000a43d00000a3f00000000000000006e4cf03a5c1db43a000000000000803f0000803f0000803f0000803f0000e83d00000a3f00000000000000006e4cf03a2045c3bb000000000000803f0000803f0000803f0000803f0000e83d0000153f0000000000000000af387bbb2045c3bb000000000000803f0000803f0000803f0000803f0000a43d0000153f00000000000000006e4cf03a5c1db43a000000000000803f0000803f0000803f0000803f0080053f00001c3e000000000000000095430b3c5c1db43a000000000000803f0000803f0000803f0000803f00800f3f00001c3e000000000000000095430b3c2045c3bb000000000000803f0000803f0000803f0000803f00800f3f0000483e00000000000000006e4cf03a2045c3bb000000000000803f0000803f0000803f0000803f0080053f0000483e0000000000000000afb9103c84f9723b000000000000803f0000803f0000803f0000803f0000a43d0000153f00000000000000007f6a3c3c84f9723b000000000000803f0000803f0000803f0000803f0000c43d0000153f00000000000000007f6a3c3cec58b8bb000000000000803f0000803f0000803f0000803f0000c43d0000233f0000000000000000afb9103cec58b8bb000000000000803f0000803f0000803f0000803f0000a43d0000233f000000000000000099e0413c5c1db43a000000000000803f0000803f0000803f0000803f0080053f00001c3e0000000000000000508d973c5c1db43a000000000000803f0000803f0000803f0000803f00800f3f00001c3e0000000000000000508d973c2045c3bb000000000000803f0000803f0000803f0000803f00800f3f0000483e000000000000000099e0413c2045c3bb000000000000803f0000803f0000803f0000803f0080053f0000483e00000000000000005d489a3c5c1db43a000000000000803f0000803f0000803f0000803f0000000000002d3f0000000000000000203ec33c5c1db43a000000000000803f0000803f0000803f0000803f0000f03c00002d3f0000000000000000203ec33cec58b8bb000000000000803f0000803f0000803f0000803f0000f03c0080373f00000000000000005d489a3cec58b8bb000000000000803f0000803f0000803f0000803f000000000080373f0000000000000000
+    _typelessdata: 1483c0bc5c1db43a000000000000803f0000803f0000803f0000803f0000063f00009a3e0000000000000000371792bc5c1db43a000000000000803f0000803f0000803f0000803f00800e3f00009a3e0000000000000000371792bc2045c3bb000000000000803f0000803f0000803f0000803f00800e3f0000b03e00000000000000001483c0bc2045c3bb000000000000803f0000803f0000803f0000803f0000063f0000b03e000000000000000044d294bc5c1db43a000000000000803f0000803f0000803f0000803f0000f83e0000b23e0000000000000000806a3cbc5c1db43a000000000000803f0000803f0000803f0000803f0000063f0000b23e0000000000000000806a3cbc2045c3bb000000000000803f0000803f0000803f0000803f0000063f0000c83e000000000000000044d294bc2045c3bb000000000000803f0000803f0000803f0000803f0000f83e0000c83e00000000000000009be041bce6971b3b000000000000803f0000803f0000803f0000803f00806d3f00009c3e0000000000000000f7fdd4bbe6971b3b000000000000803f0000803f0000803f0000803f0080753f00009c3e0000000000000000f7fdd4bb2045c3bb000000000000803f0000803f0000803f0000803f0080753f0000b53e00000000000000009be041bc2045c3bb000000000000803f0000803f0000803f0000803f00806d3f0000b53e00000000000000005fd6eabb8480a2bb000000000000803f0000803f0000803f0000803f0000563f0000623e0000000000000000f7fdd4bb8480a2bb000000000000803f0000803f0000803f0000803f0000573f0000623e0000000000000000f7fdd4bbec58b8bb000000000000803f0000803f0000803f0000803f0000573f0000663e00000000000000005fd6eabbec58b8bb000000000000803f0000803f0000803f0000803f0000563f0000663e0000000000000000af387bbb5c1db43a000000000000803f0000803f0000803f0000803f00005c3f00008f3e00000000000000006e4cf03a5c1db43a000000000000803f0000803f0000803f0000803f0080643f00008f3e00000000000000006e4cf03a2045c3bb000000000000803f0000803f0000803f0000803f0080643f0000a53e0000000000000000af387bbb2045c3bb000000000000803f0000803f0000803f0000803f00005c3f0000a53e00000000000000006e4cf03a5c1db43a000000000000803f0000803f0000803f0000803f0000743f0000803e000000000000000095430b3c5c1db43a000000000000803f0000803f0000803f0000803f00007e3f0000803e000000000000000095430b3c2045c3bb000000000000803f0000803f0000803f0000803f00007e3f0000963e00000000000000006e4cf03a2045c3bb000000000000803f0000803f0000803f0000803f0000743f0000963e0000000000000000afb9103c84f9723b000000000000803f0000803f0000803f0000803f0000703f0000803e00000000000000007f6a3c3c84f9723b000000000000803f0000803f0000803f0000803f0000743f0000803e00000000000000007f6a3c3cec58b8bb000000000000803f0000803f0000803f0000803f0000743f00009c3e0000000000000000afb9103cec58b8bb000000000000803f0000803f0000803f0000803f0000703f00009c3e000000000000000099e0413c5c1db43a000000000000803f0000803f0000803f0000803f0000743f0000803e0000000000000000508d973c5c1db43a000000000000803f0000803f0000803f0000803f00007e3f0000803e0000000000000000508d973c2045c3bb000000000000803f0000803f0000803f0000803f00007e3f0000963e000000000000000099e0413c2045c3bb000000000000803f0000803f0000803f0000803f0000743f0000963e00000000000000005d489a3c5c1db43a000000000000803f0000803f0000803f0000803f0000663f00008f3e0000000000000000203ec33c5c1db43a000000000000803f0000803f0000803f0000803f00806d3f00008f3e0000000000000000203ec33cec58b8bb000000000000803f0000803f0000803f0000803f00806d3f0000a43e00000000000000005d489a3cec58b8bb000000000000803f0000803f0000803f0000803f0000663f0000a43e0000000000000000
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -10342,6 +16983,38 @@ CanvasRenderer:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 850768005}
+--- !u!1 &857226718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1408958811752014, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 857226719}
+  m_Layer: 0
+  m_Name: Color Swatch (23)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &857226719
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4116706841807094, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 857226718}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 0.8474312, y: 3.36, z: -0.84}
+  m_LocalScale: {x: 0.3872106, y: 0.38720962, z: 0.38720992}
+  m_Children:
+  - {fileID: 891995294}
+  - {fileID: 1075048953}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &860369301
 GameObject:
   m_ObjectHideFlags: 0
@@ -10372,6 +17045,82 @@ Transform:
   m_Father: {fileID: 1433105876}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &863751455
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1360339756953396, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 863751456}
+  - component: {fileID: 863751458}
+  - component: {fileID: 863751457}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &863751456
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4235219057417848, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 863751455}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: -0.04064959, y: 0.1844779, z: -0.0465815}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1163955907}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &863751457
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23316597481889614, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 863751455}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &863751458
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33986043059763514, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 863751455}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &865060039
 GameObject:
   m_ObjectHideFlags: 0
@@ -10544,6 +17293,82 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!1 &866310162
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1078192683723128, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 866310163}
+  - component: {fileID: 866310165}
+  - component: {fileID: 866310164}
+  m_Layer: 0
+  m_Name: Palette Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &866310163
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4640643547480766, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 866310162}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -2.13, y: 0.86, z: -0.62}
+  m_LocalScale: {x: 0.38567767, y: 0.38567722, z: 0.3856773}
+  m_Children: []
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -84.809006, y: 179.99998, z: 0}
+--- !u!23 &866310164
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23142211945055586, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 866310162}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &866310165
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33035271582259614, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 866310162}
+  m_Mesh: {fileID: 4300000, guid: 227d60f96842d1b42bba085a09883cd9, type: 3}
 --- !u!1001 &871255032
 Prefab:
   m_ObjectHideFlags: 0
@@ -10560,6 +17385,11 @@ Prefab:
         type: 2}
       propertyPath: soundEffect._clips.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4000013939052844, guid: c915520bed265f24c95aebc38ee51557, type: 2}
       propertyPath: m_LocalPosition.x
@@ -10655,6 +17485,31 @@ Prefab:
       value: 
       objectReference: {fileID: 243000011340830754, guid: 43de2443e9a4ff54e842fdf9d3168906,
         type: 2}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1840705451}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: NotifyColorPalleteTouched
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c915520bed265f24c95aebc38ee51557, type: 2}
   m_IsPrefabParent: 0
@@ -10674,6 +17529,38 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 871255032}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &872341592
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1597165900393370, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 872341593}
+  m_Layer: 0
+  m_Name: Color Swatch (11)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &872341593
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4896412102367300, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 872341592}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 1.7036352, y: 1.86, z: -0.71}
+  m_LocalScale: {x: 0.38721025, y: 0.38720945, z: 0.38720974}
+  m_Children:
+  - {fileID: 299680014}
+  - {fileID: 1789897691}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &875728041
 GameObject:
   m_ObjectHideFlags: 0
@@ -10732,6 +17619,78 @@ MonoBehaviour:
   scaleLastFingerBone: 0
   modelFingerPointing: {x: -1, y: 0, z: 0}
   modelPalmFacing: {x: 0, y: 1, z: 0}
+--- !u!1 &884648089
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 884648090}
+  - component: {fileID: 884648092}
+  - component: {fileID: 884648091}
+  m_Layer: 0
+  m_Name: Button Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &884648090
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 884648089}
+  m_LocalRotation: {x: 0, y: -0.7071068, z: 0.7071068, w: 0}
+  m_LocalPosition: {x: -0, y: 0.4, z: -0}
+  m_LocalScale: {x: 1.7891774, y: 1.7891778, z: 1.7891778}
+  m_Children: []
+  m_Father: {fileID: 505945872}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 180}
+--- !u!23 &884648091
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 884648089}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: a3f409b80bd24d04f8a89e2b3adadefe, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &884648092
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 884648089}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &884914782
 GameObject:
   m_ObjectHideFlags: 0
@@ -10817,6 +17776,84 @@ Transform:
   m_Father: {fileID: 1948294872}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &887154783
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1588866149958016, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 887154784}
+  - component: {fileID: 887154786}
+  - component: {fileID: 887154785}
+  m_Layer: 0
+  m_Name: Cleaning Basin Liquid
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &887154784
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4574867020176512, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 887154783}
+  m_LocalRotation: {x: 0.32394975, y: 0.6285352, z: 0.6285351, w: 0.32395014}
+  m_LocalPosition: {x: 0.03, y: 0.011, z: 0.126}
+  m_LocalScale: {x: 0.15294802, y: 0.2836621, z: 0.102143206}
+  m_Children:
+  - {fileID: 296206386}
+  - {fileID: 508224417}
+  m_Father: {fileID: 1194378814}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: -35.459003, y: 90.00001, z: 90.00001}
+--- !u!23 &887154785
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23186928406286980, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 887154783}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: a43c59e2d83e5fd4f873cc402fd3d496, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &887154786
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33176972553767204, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 887154783}
+  m_Mesh: {fileID: 4300000, guid: 82e09e51c1efb98489fc03d6af9dfbec, type: 3}
 --- !u!1 &891268380
 GameObject:
   m_ObjectHideFlags: 0
@@ -10845,6 +17882,113 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2113609787}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &891995293
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1755663606638378, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 891995294}
+  - component: {fileID: 891995296}
+  - component: {fileID: 891995295}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &891995294
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4842209730766000, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 891995293}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.14113572, y: -0.28401265, z: 0.40929517}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 857226719}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &891995295
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23240428405923520, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 891995293}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &891995296
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33647223286350964, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 891995293}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &892674013
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1981108457197728, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 892674014}
+  m_Layer: 5
+  m_Name: Icon Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &892674014
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4144411446451180, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 892674013}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7, y: 0.7, z: 0.7}
+  m_Children:
+  - {fileID: 655833091}
+  m_Father: {fileID: 1826535516}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &893001486
@@ -10899,7 +18043,7 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 893001486}
-  m_Mesh: {fileID: 953872466}
+  m_Mesh: {fileID: 1912623243}
 --- !u!23 &893001490
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -11143,6 +18287,11 @@ Prefab:
       propertyPath: soundEffect._clips.Array.size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4000013939052844, guid: c915520bed265f24c95aebc38ee51557, type: 2}
       propertyPath: m_LocalPosition.x
       value: -2.1300027
@@ -11237,6 +18386,31 @@ Prefab:
       value: 
       objectReference: {fileID: 243000011340830754, guid: 43de2443e9a4ff54e842fdf9d3168906,
         type: 2}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1840705451}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: NotifyColorPalleteTouched
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c915520bed265f24c95aebc38ee51557, type: 2}
   m_IsPrefabParent: 0
@@ -11674,6 +18848,78 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1 &927448599
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 927448600}
+  - component: {fileID: 927448602}
+  - component: {fileID: 927448601}
+  m_Layer: 0
+  m_Name: RectToroid (Pinch Target)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &927448600
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 927448599}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 130672513}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &927448601
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 927448599}
+  m_Mesh: {fileID: 0}
+--- !u!23 &927448602
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 927448599}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &931763936
 GameObject:
   m_ObjectHideFlags: 0
@@ -11759,6 +19005,125 @@ Transform:
   m_Father: {fileID: 2038811063}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: -86.712006, y: -21.665, z: -160}
+--- !u!1 &934590209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1114902606273330, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 934590210}
+  - component: {fileID: 934590212}
+  - component: {fileID: 934590211}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &934590210
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4682623644140672, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 934590209}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.02856192, y: 0.48795506, z: 0.04018712}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1222972609}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &934590211
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23889819573519884, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 934590209}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &934590212
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33391209894619048, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 934590209}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &939237214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 939237215}
+  - component: {fileID: 939237216}
+  m_Layer: 0
+  m_Name: Then pinch (waiting)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &939237215
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 939237214}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &939237216
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 939237214}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 773ca6312a6d68d4e9b533f3026cb9c9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1962621079}
+  transitionState: {fileID: 0}
+  forDuration: 1
 --- !u!1 &948024598
 GameObject:
   m_ObjectHideFlags: 0
@@ -12009,152 +19374,245 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
---- !u!43 &953872466
-Mesh:
+--- !u!1 &955555648
+GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: Ribbon Circle Mesh
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 1536
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 256
-    localAABB:
-      m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-      m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
-  m_Skin: []
-  m_VertexData:
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 955555649}
+  - component: {fileID: 955555651}
+  - component: {fileID: 955555650}
+  m_Layer: 0
+  m_Name: Sphere (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &955555649
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 955555648}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.0059999996, y: 0.009600004, z: -0.026800036}
+  m_LocalScale: {x: 0.002800687, y: 0.0028006851, z: 0.0028006851}
+  m_Children: []
+  m_Father: {fileID: 47246601}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &955555650
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 955555648}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &955555651
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 955555648}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &955697614
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000013177057670, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 955697615}
+  m_Layer: 0
+  m_Name: Pinky
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &955697615
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012112317530, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 955697614}
+  m_LocalRotation: {x: -0.85746807, y: 0.008781079, z: 0.081204705, w: 0.508013}
+  m_LocalPosition: {x: 0.17899796, y: 1.5368698, z: 1.1936836}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &959373735
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 959373736}
+  - component: {fileID: 959373739}
+  - component: {fileID: 959373738}
+  - component: {fileID: 959373737}
+  m_Layer: 0
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &959373736
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 959373735}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 1.677}
+  m_LocalScale: {x: 0.003, y: 0.003, z: 0.003}
+  m_Children:
+  - {fileID: 1260164693}
+  m_Father: {fileID: 1649983740}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1.5}
+  m_SizeDelta: {x: 400, y: 250}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &959373737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 959373735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1301386320, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
     serializedVersion: 2
-    m_VertexCount: 256
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 6144
-    _typelessdata: d9cef73c6f12833900000000a681353fa881343f67393ebc45b6f33c6f128339000000003e8034bf1e83353f822e3dbcd9cef73c6f1283b900000000a681353fa88134bf233d3e3c45b6f33c6f1283b9000000003e8034bf1e8335bfbb2a3d3c5e9df63c6f128339c15042bb5d57343f9c81343f59fda5bdd889f23c6f128339871a3fbbf2eb33bf1383353f8d026c3d5e9df63c6f1283b9c15042bb87ec343f9c8134bf5c536dbdd889f23c6f1283b9871a3fbb9b5733bf148335bf0912a53de30bf33c6f1283393861c1bb6270313fa581343f2a4d19be7507ef3c6f128339f42ebebbfb9b31bf1e83353f8c42013ee30bf33c6f1283b93861c1bb4699323fa58134bfd2fa01be7507ef3c6f1283b9f42ebebbbf7430bf1e8335bfb973183e3023ed3c6f128339a6de0fbc02d42c3f9e81343fa2215ebec437e93c6f128339e07d0dbc39962dbf1683353fc745463e3023ed3c6f1283b9a6de0fbcc48d2e3f9c8134bf956047bec437e93c6f1283b9e07d0dbce9de2bbf188335bf9de65c3edaf1e43c6f128339fea93dbc7e8d263fa281343f476990be1829e13c6f12833972873abc71e427bf1983353f17b0843edaf1e43c6f1283b9fea93dbcded3283fa08134bf4f6d85be1829e13c6f1283b972873abc49a125bf198335bf759c8f3e108cda3c6f128339bba169bc64ac1e3f9d81343fa95db0be4eefd63c6f12833923c565bcc89420bf1083353f37f6a43e108cda3c6f1283b9bba169bcc579213f988134bf79e1a5be4eefd63c6f1283b923c565bc5dcb1dbf158335bf8c63af3e790bce3c6f128339bbac89bc1544153f9b81343f3d9fcebe9da3ca3c6f1283392d6687bc24b917bf1d83353f86a5c33e790bce3c6f1283b9bbac89bc8591183fa78134bf84bcc4be9da3ca3c6f1283b92d6687bc647014bf128335bf427acd3ee48ebf3c6f1283392d359dbcb06b0a3fac81343f5ee3eabe5464bc3c6f128339f79b9abc7a670dbf2183353f8d72e03ee48ebf3c6f1283b92d359dbc22310e3fa88134bfa0b2e1be5464bc3c6f1283b9f79b9abc65a709bf268335bf3a96e93e093aaf3c6f128339083aafbc567cfc3e9f81343f3b7202bf9554ac3c6f1283399454acbc3eb901bf1783353f3e16fb3e093aaf3c6f1283b9083aafbc3b72023f9f8134bf567cfcbe9554ac3c6f1283b99454acbc3d16fbbe178335bf3eb9013f2e359d3c6f128339e38ebfbca0b2e13ea981343f23310ebff89b9a3c6f1283395364bcbc3a96e9be2683353f64a7093f2e359d3c6f1283b9e38ebfbc5ee3ea3eac8134bfb06b0abff89b9a3c6f1283b95364bcbc8d72e0be218335bf7a670d3fbcac893c6f128339780bcebc80bcc43ea581343f859118bf2e66873c6f1283399ca3cabc3f7acdbe1283353f6470143fbcac893c6f1283b9780bcebc3b9fce3e9b8134bf144415bf2e66873c6f1283b99ca3cabc86a5c3be1d8335bf27b9173fbca1693c6f1283390f8cdabc78e1a53e9a81343fc67921bf24c5653c6f1283394defd6bc8963afbe1483353f5ecb1d3fbca1693c6f1283b90f8cdabca75db03e9c8134bf64ac1ebf24c5653c6f1283b94defd6bc36f6a4be108335bfc794203fffa93d3c6f128339d9f1e4bc506d853ea081343fddd328bf73873a3c6f1283391729e1bc769c8fbe1983353f49a1253fffa93d3c6f1283b9d9f1e4bc4869903ea18134bf7d8d26bf73873a3c6f1283b91729e1bc18b084be198335bf70e4273fa8de0f3c6f1283392f23edbc9760473e9c81343fc58d2ebfe27d0d3c6f128339c337e9bc9ee65cbe1883353fe6de2b3fa8de0f3c6f1283b92f23edbca2215e3e9e8134bf01d42cbfe27d0d3c6f1283b9c337e9bcc94546be158335bf39962d3f3c61c13b6f128339e20bf3bce6fa013ea581343f459932bff82ebe3b6f1283397407efbcc27318be1d83353fbe74303f3c61c13b6f1283b9e20bf3bc344d193ea58134bf627031bff82ebe3b6f1283b97407efbca04201be1e8335bffb9b313fca50423b6f1283395e9df6bc34536d3d9b81343f87ec34bf901a3f3b6f128339d889f2bc1e12a5bd1483353f9b57333fca50423b6f1283b95e9df6bc6cfda53d9c8134bf5c5734bf901a3f3b6f1283b9d889f2bc64026cbd138335bff2eb333fea4918316f128339d8cef7bc073a3ebca781343fa68135bf84c515316f12833944b6f3bc5d2b3dbc1e83353f3e80343fea4918316f1283b9d8cef7bc073a3e3ca88134bfa68135bf84c515316f1283b944b6f3bc5d2b3d3c1e8335bf3e80343fb75042bb6f1283395e9df6bc46fda5bd9c81343f5d5734bf7d1a3fbb6f128339d889f2bc40026c3d1283353ff3eb333fb75042bb6f1283b95e9df6bc0d536dbd9b8134bf88ec34bf7d1a3fbb6f1283b9d889f2bcf811a53d168335bf9c57333f3261c1bb6f128339e30bf3bc2b4d19bea581343f627031bfee2ebebb6f1283397507efbc8c42013e1e83353ffb9b313f3261c1bb6f1283b9e30bf3bcd3fa01bea68134bf459932bfee2ebebb6f1283b97507efbcb973183e1d8335bfbe74303fa3de0fbc6f1283393023edbca2215ebe9e81343f02d42cbfdd7d0dbc6f128339c437e9bcc745463e1683353f39962d3fa3de0fbc6f1283b93023edbc956047be9c8134bfc48d2ebfdd7d0dbc6f1283b9c437e9bc9de65c3e188335bfe9de2b3ffba93dbc6f128339daf1e4bc476990bea281343f7e8d26bf6f873abc6f1283391829e1bc17b0843e1983353f71e4273ffba93dbc6f1283b9daf1e4bc4f6d85bea08134bfded328bf6f873abc6f1283b91829e1bc759c8f3e198335bf49a1253fb8a169bc6f128339108cdabca75db0be9c81343f64ac1ebf20c565bc6f1283394eefd6bc36f6a43e1083353fc794203fb8a169bc6f1283b9108cdabc78e1a5be9a8134bfc67921bf20c565bc6f1283b94eefd6bc8b63af3e148335bf5ecb1d3fbaac89bc6f128339790bcebc3c9fcebe9b81343f154415bf2c6687bc6f1283399da3cabc85a5c33e1d83353f26b9173fbaac89bc6f1283b9790bcebc80bcc4bea68134bf859118bf2c6687bc6f1283b99da3cabc3f7acd3e128335bf6470143f2c359dbc6f128339e48ebfbc5be3eabeac81343fb36b0abff69b9abc6f1283395464bcbc8972e03e2283353f79670d3f2c359dbc6f1283b9e48ebfbc9db2e1bea98134bf23310ebff69b9abc6f1283b95464bcbc3696e93e258335bf67a7093f083aafbc6f128339093aafbc3b7202bfa181343f517cfcbe9454acbc6f1283399554acbc3e16fb3e1683353f40b9013f083aafbc6f1283b9093aafbc567cfcbe9c8134bf3e7202bf9454acbc6f1283b99554acbc3eb9013f1a8335bf3816fb3ee28ebfbc6f1283392e359dbc25310ebfa881343f9eb2e1be5264bcbc6f128339f89b9abc66a7093f2783353f3396e93ee28ebfbc6f1283b92e359dbcb36b0abfaf8134bf59e3eabe5264bcbc6f1283b9f89b9abc7b670d3f1f8335bf8a72e03e770bcebc6f128339bcac89bc859118bfa781343f84bcc4be9ba3cabc6f1283392e6687bc6470143f1283353f427acd3e770bcebc6f1283b9bcac89bc154415bf9b8134bf3d9fcebe9ba3cabc6f1283b92e6687bc24b9173f1d8335bf86a5c33e0e8cdabc6f128339bda169bcc57921bf9881343f79e1a5be4cefd6bc6f12833925c565bc5dcb1d3f1583353f8b63af3e0e8cdabc6f1283b9bda169bc64ac1ebf9d8134bfa95db0be4cefd6bc6f1283b925c565bcc794203f108335bf37f6a43ed8f1e4bc6f12833900aa3dbcded328bfa181343f516d85be1629e1bc6f12833974873abc4aa1253f1a83353f779c8f3ed8f1e4bc6f1283b900aa3dbc7d8d26bfa18134bf486990be1629e1bc6f1283b974873abc70e4273f198335bf18b0843e2e23edbc6f128339a9de0fbcc58d2ebf9c81343f976047bec237e9bc6f128339e37d0dbce7de2b3f1983353f9fe65c3e2e23edbc6f1283b9a9de0fbc01d42cbf9e8134bfa2215ebec237e9bc6f1283b9e37d0dbc38962d3f148335bfc745463ee10bf3bc6f1283393e61c1bb459932bfa681343fe7fa01be7307efbc6f128339fa2ebebbbe74303f1d83353fc373183ee10bf3bc6f1283b93e61c1bb627031bfa58134bf354d19be7307efbc6f1283b9fa2ebebbfa9b313f1e8335bfa042013e5d9df6bc6f128339cf5042bb88ec34bf9b81343f35536dbdd789f2bc6f128339951a3fbb9b57333f1583353f1f12a53d5d9df6bc6f1283b9cf5042bb5c5734bf9c8134bf6dfda5bdd789f2bc6f1283b9951a3fbbf3eb333f148335bf67026c3dd7cef7bc6f128339228071b1a68135bfa781343f073a3e3c43b6f3bc6f12833940826db13e80343f1f83353f5e2b3d3cd7cef7bc6f1283b9228071b1a68135bfa78134bf073a3ebc43b6f3bc6f1283b940826db13e80343f1f8335bf5e2b3dbc5d9df6bc6f128339b150423b5c5734bf9c81343f46fda53dd789f2bc6f128339771a3f3bf3eb333f1283353f40026cbd5d9df6bc6f1283b9b150423b88ec34bf9b8134bf0d536d3dd789f2bc6f1283b9771a3f3b9b57333f158335bff611a5bde20bf3bc6f1283392f61c13b637031bfa481343f2a4d193e7407efbc6f128339eb2ebe3bfb9b313f1e83353f8c4201bee20bf3bc6f1283b92f61c13b469932bfa68134bfd3fa013e7407efbc6f1283b9eb2ebe3bbf74303f1e8335bfb97318be2f23edbc6f128339a2de0f3c01d42cbf9e81343fa2215e3ec337e9bc6f128339dc7d0d3c39962d3f1583353fc74546be2f23edbc6f1283b9a2de0f3cc58d2ebf9b8134bf9560473ec337e9bc6f1283b9dc7d0d3ce7de2b3f198335bf9ee65cbed9f1e4bc6f128339f9a93d3c7d8d26bfa081343f4869903e1729e1bc6f1283396d873a3c70e4273f1983353f18b084bed9f1e4bc6f1283b9f9a93d3cded328bfa18134bf516d853e1729e1bc6f1283b96d873a3c4aa1253f1a8335bf779c8fbe0f8cdabc6f128339b6a1693c64ac1ebf9c81343fa75db03e4defd6bc6f1283391ec5653cc794203f1083353f36f6a4be0f8cdabc6f1283b9b6a1693cc57921bf998134bf77e1a53e4defd6bc6f1283b91ec5653c5ecb1d3f148335bf8b63afbe780bcebc6f128339b9ac893c154415bf9b81343f3c9fce3e9ca3cabc6f1283392b66873c27b9173f1e83353f86a5c3be780bcebc6f1283b9b9ac893c859118bfa68134bf80bcc43e9ca3cabc6f1283b92b66873c6470143f128335bf3f7acdbee38ebfbc6f1283392b359d3cb36b0abfac81343f5be3ea3e5364bcbc6f128339f59b9a3c79670d3f2283353f8972e0bee38ebfbc6f1283b92b359d3c23310ebfa98134bf9db2e13e5364bcbc6f1283b9f59b9a3c67a7093f258335bf3696e9be083aafbc6f128339073aaf3c507cfcbea081343f3a72023f9454acbc6f1283399354ac3c40b9013f1683353f3e16fbbe083aafbc6f1283b9073aaf3c3e7202bf9c8134bf567cfc3e9454acbc6f1283b99354ac3c3816fb3e1a8335bf3eb901bf2d359dbc6f128339e18ebf3c9eb2e1bea881343f25310e3ff79b9abc6f1283395164bc3c3296e93e2683353f65a709bf2d359dbc6f1283b9e18ebf3c57e3eabeae8134bfb26b0a3ff79b9abc6f1283b95164bc3c8a72e03e1f8335bf7b670dbfbbac89bc6f128339760bce3c84bcc4bea781343f8591183f2d6687bc6f1283399aa3ca3c427acd3e1283353f647014bfbbac89bc6f1283b9760bce3c3d9fcebe9b8134bf1544153f2d6687bc6f1283b99aa3ca3c86a5c33e1d8335bf24b917bfbba169bc6f1283390d8cda3c79e1a5be9881343fc579213f23c565bc6f1283394befd63c8b63af3e1583353f5dcb1dbfbba169bc6f1283b90d8cda3ca95db0be9d8134bf64ac1e3f23c565bc6f1283b94befd63c37f6a43e108335bfc79420bffea93dbc6f128339d7f1e43c506d85bea081343fddd3283f72873abc6f1283391529e13c769c8f3e1983353f49a125bffea93dbc6f1283b9d7f1e43c486990bea18134bf7d8d263f72873abc6f1283b91529e13c18b0843e198335bf70e427bfa7de0fbc6f1283392d23ed3c976047be9c81343fc58d2e3fe17d0dbc6f128339c137e93c9ee65c3e1883353fe6de2bbfa7de0fbc6f1283b92d23ed3ca2215ebe9e8134bf01d42c3fe17d0dbc6f1283b9c137e93cc945463e158335bf39962dbf3a61c1bb6f128339e00bf33ce7fa01bea681343f4599323ff62ebebb6f1283397207ef3cc373183e1d83353fbe7430bf3a61c1bb6f1283b9e00bf33c354d19bea58134bf6270313ff62ebebb6f1283b97207ef3ca042013e1e8335bffa9b31bfc85042bb6f1283395c9df63c35536dbd9b81343f87ec343f8e1a3fbb6f128339d689f23c2012a53d1583353f9b5733bfc85042bb6f1283b95c9df63c6efda5bd9c8134bf5c57343f8e1a3fbb6f1283b9d689f23c67026c3d148335bff2eb33bf56c011b16f128339d6cef73c083a3e3ca681343fa681353f9a570fb16f12833942b6f33c5e2b3d3c1e83353f3e8034bf56c011b16f1283b9d6cef73c083a3ebca68134bfa681353f9a570fb16f1283b942b6f33c5e2b3dbc1e8335bf3e8034bfb650423b6f1283395c9df63c48fda53d9d81343f5d57343f7c1a3f3b6f128339d689f23c42026cbd1483353ff3eb33bfb650423b6f1283b95c9df63c0f536d3d9b8134bf88ec343f7c1a3f3b6f1283b9d689f23cf811a5bd158335bf9b5733bf3161c13b6f128339e10bf33c2a4d193ea481343f6370313fed2ebe3b6f1283397307ef3c8c4201be1e83353ffb9b31bf3161c13b6f1283b9e10bf33cd3fa013ea68134bf4699323fed2ebe3b6f1283b97307ef3cb97318be1d8335bfbf7430bfa3de0f3c6f1283392e23ed3ca2215e3e9e81343f01d42c3fdd7d0d3c6f128339c237e93cc74546be1583353f39962dbfa3de0f3c6f1283b92e23ed3c9560473e9b8134bfc58d2e3fdd7d0d3c6f1283b9c237e93c9ee65cbe198335bfe7de2bbffaa93d3c6f128339d8f1e43c4869903ea081343f7d8d263f6e873a3c6f1283391629e13c18b084be1983353f70e427bffaa93d3c6f1283b9d8f1e43c506d853ea08134bfddd3283f6e873a3c6f1283b91629e13c769c8fbe198335bf49a125bfb7a1693c6f1283390e8cda3ca95db03e9d81343f64ac1e3f1fc5653c6f1283394cefd63c37f6a4be1083353fc89420bfb7a1693c6f1283b90e8cda3c79e1a53e988134bfc579213f1fc5653c6f1283b94cefd63c8c63afbe158335bf5dcb1dbfb9ac893c6f128339770bce3c3d9fce3e9b81343f1544153f2b66873c6f1283399ba3ca3c86a5c3be1d83353f24b917bfb9ac893c6f1283b9770bce3c84bcc43ea78134bf8591183f2b66873c6f1283b99ba3ca3c427acdbe128335bf647014bf2b359d3c6f128339e28ebf3c54e3ea3eac81343fb56b0a3ff59b9a3c6f1283395264bc3c8872e0be2183353f7c670dbf2b359d3c6f1283b9e28ebf3c9ab2e13ea88134bf24310e3ff59b9a3c6f1283b95264bc3c2f96e9be268335bf69a709bf073aaf3c6f128339083aaf3c3e72023f9f81343f517cfc3e9354ac3c6f1283399454ac3c3916fbbe1983353f40b901bf073aaf3c6f1283b9083aaf3c517cfc3e9f8134bf3e72023f9354ac3c6f1283b99454ac3c40b901bf178335bf3816fbbee18ebf3c6f1283392c359d3c24310e3fa881343f99b2e13e5164bc3c6f128339f69b9a3c68a709bf2583353f2f96e9bee18ebf3c6f1283b92c359d3cb56b0a3fac8134bf54e3ea3e5164bc3c6f1283b9f69b9a3c7b670dbf218335bf8772e0be760bce3c6f128339baac893c8591183fa781343f84bcc43e9aa3ca3c6f1283392c66873c647014bf1283353f427acdbe760bce3c6f1283b9baac893c1544153f9b8134bf3d9fce3e9aa3ca3c6f1283b92c66873c24b917bf1d8335bf86a5c3be0d8cda3c6f128339b9a1693cc579213f9881343f79e1a53e4befd63c6f12833921c5653c5dcb1dbf1583353f8b63afbe0d8cda3c6f1283b9b9a1693c64ac1e3f9d8134bfa95db03e4befd63c6f1283b921c5653cc79420bf108335bf37f6a4bed7f1e43c6f128339fca93d3cded3283fa181343f516d853e1529e13c6f12833970873a3c4aa125bf1a83353f779c8fbed7f1e43c6f1283b9fca93d3c7d8d263fa18134bf4869903e1529e13c6f1283b970873a3c70e427bf198335bf18b084be2d23ed3c6f128339a5de0f3cc58d2e3f9c81343f9760473ec137e93c6f128339df7d0d3ce7de2bbf1983353f9fe65cbe2d23ed3c6f1283b9a5de0f3c01d42c3f9e8134bfa2215e3ec137e93c6f1283b9df7d0d3c38962dbf148335bfc74546bee00bf33c6f1283393661c13b4599323fa681343fe7fa013e7207ef3c6f128339f22ebe3bbe7430bf1d83353fc37318bee00bf33c6f1283b93661c13b6270313fa58134bf354d193e7207ef3c6f1283b9f22ebe3bfa9b31bf1e8335bfa04201be5c9df63c6f128339c050423b87ec343f9b81343f25546d3dd689f23c6f128339861a3f3b9a5733bf1483353f5a12a5bd5c9df63c6f1283b9c050423b5b57343f9c8134bfa9fda53dd689f23c6f1283b9861a3f3bf1eb33bf138335bf57036cbd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-    m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
+    m_Bits: 4294967295
+--- !u!114 &959373738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 959373735}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 1980459831, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+--- !u!223 &959373739
+Canvas:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 959373735}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!1 &960477181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 960477182}
+  - component: {fileID: 960477183}
+  m_Layer: 0
+  m_Name: Open your hand (waiting)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &960477182
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 960477181}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &960477183
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 960477181}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1716d772c0cb5a2408c7d21186c68544, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1809244139}
+  transitionState: {fileID: 0}
+  forDuration: 1.5
 --- !u!1001 &972121096
 Prefab:
   m_ObjectHideFlags: 0
@@ -12408,6 +19866,110 @@ MonoBehaviour:
   OnAngle: 45
   OffAngle: 55
   ShowGizmos: 0
+--- !u!1 &990536908
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1719919602826544, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 990536909}
+  m_Layer: 0
+  m_Name: Color Swatch (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &990536909
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4990206722127984, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 990536908}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -2.6159534, y: 0.38, z: -0.57}
+  m_LocalScale: {x: 0.38721025, y: 0.38720945, z: 0.38720974}
+  m_Children:
+  - {fileID: 785999787}
+  - {fileID: 1830468854}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &991967091
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 991967092}
+  - component: {fileID: 991967094}
+  - component: {fileID: 991967093}
+  m_Layer: 0
+  m_Name: Cube (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &991967092
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 991967091}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.411, y: 0.4569999, z: 0.46400028}
+  m_LocalScale: {x: 0.2424476, y: 0.24244757, z: 0.24244757}
+  m_Children: []
+  m_Father: {fileID: 1555422911}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &991967093
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 991967091}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d2e7353916bd3c438be7c48258805b2, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &991967094
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 991967091}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &993634891
 GameObject:
   m_ObjectHideFlags: 0
@@ -12802,6 +20364,67 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1014066620}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1018588568
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1018588569}
+  m_Layer: 0
+  m_Name: DiscontinuityGizmo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1018588569
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1018588568}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.902, z: 1.652}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1649983740}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1025233047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1264535452909336, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1025233048}
+  m_Layer: 0
+  m_Name: Color Swatch (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1025233048
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4393444476051190, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1025233047}
+  m_LocalRotation: {x: -2.1605053e-14, y: -0.00000007375698, z: 0.000000031610053,
+    w: 1}
+  m_LocalPosition: {x: 2.10001, y: 0.09999059, z: 0.020003093}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 129239385}
+  - {fileID: 361661856}
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1035963640
 Prefab:
   m_ObjectHideFlags: 0
@@ -13049,8 +20672,7 @@ Transform:
   m_LocalPosition: {x: -0.21999995, y: -0.1295433, z: 0.2595414}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 2085845413}
-  - {fileID: 435133762}
+  - {fileID: 398019397}
   - {fileID: 1118740493}
   - {fileID: 1122853878}
   - {fileID: 1325899577}
@@ -13071,6 +20693,36 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DeactivateOnDisable: 0
   Transition: {fileID: 0}
+--- !u!1 &1050640147
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1050640148}
+  m_Layer: 0
+  m_Name: UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1050640148
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1050640147}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.04, y: 0.04, z: 0.04}
+  m_Children:
+  - {fileID: 2010003633}
+  - {fileID: 1832814775}
+  m_Father: {fileID: 1649983740}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1057167255
 Prefab:
   m_ObjectHideFlags: 0
@@ -13527,6 +21179,114 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &1064702618
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1311577686343682, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1064702619}
+  m_Layer: 0
+  m_Name: Color Swatch
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1064702619
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4320734777652230, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1064702618}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 2.5482693, y: 0.38, z: -0.57}
+  m_LocalScale: {x: 0.3872095, y: 0.3872092, z: 0.38720942}
+  m_Children:
+  - {fileID: 2033409107}
+  - {fileID: 415947741}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1075048952
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1532495798802836, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1075048953}
+  - component: {fileID: 1075048955}
+  - component: {fileID: 1075048954}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1075048953
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4848200141214304, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1075048952}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.03190935, y: 0.48133862, z: -0.21363723}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 857226719}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1075048954
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23549538487508856, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1075048952}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1075048955
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33029877019951736, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1075048952}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &1077311311
 GameObject:
   m_ObjectHideFlags: 0
@@ -13953,6 +21713,196 @@ Transform:
   m_Father: {fileID: 678408571}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1094083027
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1599448170024362, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1094083028}
+  m_Layer: 0
+  m_Name: Color Swatch (16)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1094083028
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4052305591361948, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1094083027}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -2.554245, y: 1.86, z: -0.71}
+  m_LocalScale: {x: 0.38721135, y: 0.38720983, z: 0.38721022}
+  m_Children:
+  - {fileID: 1685115188}
+  - {fileID: 99731268}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1099494396
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1676478941999090, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1099494397}
+  - component: {fileID: 1099494399}
+  - component: {fileID: 1099494398}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1099494397
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4380451026655424, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099494396}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.015618362, y: 0.6917518, z: -0.21865125}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 66919111}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1099494398
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23286982957541124, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099494396}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1099494399
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33282102771293878, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1099494396}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1100233218
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1100233220}
+  - component: {fileID: 1100233219}
+  m_Layer: 0
+  m_Name: Tutorial PostProcess
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1100233219
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1100233218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3028267c9de6d214d9a3a7290e0cfdc9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  assets:
+  - {fileID: 11400000, guid: cf577d509cf1547468a2f3efeff78a3f, type: 2}
+  headPositionPath: LMHeadMountedRig/Main Camera
+  lerpStartingPosition: 0
+  startHeadPosition: {x: 0, y: 1.78, z: -0.1}
+  lerpEndingPosition: 0
+  endHeadPosition: {x: 0, y: 1.78, z: -0.1}
+  cropAnimation: 1
+  allBindings:
+  - LMHeadMountedRig/Main Camera
+--- !u!4 &1100233220
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1100233218}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.6516564, y: 1.2320504, z: 1.7099092}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1101815128
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1877428054442350, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1101815129}
+  m_Layer: 0
+  m_Name: Color Swatch (24)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1101815129
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4045893516364026, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1101815128}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 0.0027971268, y: 3.36, z: -0.84}
+  m_LocalScale: {x: 0.38721097, y: 0.3872097, z: 0.38721007}
+  m_Children:
+  - {fileID: 1261024190}
+  - {fileID: 1472483591}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 25
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1102714709
 GameObject:
   m_ObjectHideFlags: 0
@@ -14090,6 +22040,35 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _indexTipColor: {fileID: 1102714711}
+--- !u!1 &1104466512
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1104466513}
+  m_Layer: 0
+  m_Name: PinkyKnuckle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1104466513
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1104466512}
+  m_LocalRotation: {x: -0.85746807, y: 0.008781079, z: 0.081204705, w: 0.508013}
+  m_LocalPosition: {x: 0.1877059, y: 1.478569, z: 1.2251283}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1544470583}
+  m_Father: {fileID: 206834525}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1105313100
 GameObject:
   m_ObjectHideFlags: 0
@@ -14538,6 +22517,123 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _radius: 1
   _handModel: {fileID: 923751379}
+--- !u!1 &1114276459
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1114276460}
+  - component: {fileID: 1114276462}
+  - component: {fileID: 1114276461}
+  m_Layer: 0
+  m_Name: RectToroid (Pinch State)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1114276460
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1114276459}
+  m_LocalRotation: {x: 0.000000029802322, y: 0.0000000018626451, z: -0.0000000034924597,
+    w: 1}
+  m_LocalPosition: {x: -1.3237283e-10, y: -0.000000001031506, z: 0.000000011734409}
+  m_LocalScale: {x: 1.0000002, y: 1.0000008, z: 1.0000005}
+  m_Children: []
+  m_Father: {fileID: 130672513}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1114276461
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1114276459}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1114276462
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1114276459}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &1116187725
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1116187726}
+  - component: {fileID: 1116187727}
+  m_Layer: 0
+  m_Name: Tutorial Enable/Disable On Awake
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1116187726
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1116187725}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.17265373, y: 1.3808633, z: 0.5213289}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1116187727
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1116187725}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79167bbb9c3284a4a95d143f93afa081, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tutorialControl: {fileID: 1840705451}
+  tutorialEnabledOnAwake: 1
+  enableTutorialFlag: --enable-tutorial
+  disableTutorialFlag: --disable-tutorial
 --- !u!1 &1118740492
 GameObject:
   m_ObjectHideFlags: 0
@@ -14570,7 +22666,7 @@ Transform:
   - {fileID: 2045431049}
   - {fileID: 2016677802}
   m_Father: {fileID: 1046230652}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 100.406006, y: -14.677002, z: -14.411987}
 --- !u!114 &1118740494
 MonoBehaviour:
@@ -14596,6 +22692,82 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &1119727643
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1897402669863392, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1119727644}
+  - component: {fileID: 1119727646}
+  - component: {fileID: 1119727645}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1119727644
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4557688316637344, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1119727643}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.017413082, y: 0.60088754, z: 0.16025627}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1163955907}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1119727645
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23710989015743316, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1119727643}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1119727646
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33893426900198728, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1119727643}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &1122853877
 GameObject:
   m_ObjectHideFlags: 0
@@ -14628,7 +22800,7 @@ Transform:
   - {fileID: 1888140365}
   - {fileID: 387115218}
   m_Father: {fileID: 1046230652}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 96.36899, y: -57.096985, z: -59.00598}
 --- !u!114 &1122853879
 MonoBehaviour:
@@ -14715,6 +22887,220 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1130966992
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 646267621}
+    m_Modifications:
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Name
+      value: Button Surface
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &1130966993 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_PrefabInternal: {fileID: 1130966992}
+--- !u!1 &1134568024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1134568025}
+  - component: {fileID: 1134568027}
+  - component: {fileID: 1134568026}
+  m_Layer: 0
+  m_Name: Capsule (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1134568025
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1134568024}
+  m_LocalRotation: {x: 0.7071025, y: -0, z: -0, w: -0.70711106}
+  m_LocalPosition: {x: -0, y: 0.006, z: 0.019}
+  m_LocalScale: {x: 0.004024667, y: 0.011383979, z: 0.004024667}
+  m_Children: []
+  m_Father: {fileID: 1864714347}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -9090, y: 0, z: 0}
+--- !u!23 &1134568026
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1134568024}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1134568027
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1134568024}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1143031934
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1668840765763130, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1143031935}
+  - component: {fileID: 1143031937}
+  - component: {fileID: 1143031936}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1143031935
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4601218460753726, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1143031934}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.05802944, y: 0.35614765, z: -0.32158917}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 114110166}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1143031936
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23123172196470242, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1143031934}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1143031937
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33110930284619036, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1143031934}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &1144605978
 GameObject:
   m_ObjectHideFlags: 0
@@ -14828,6 +23214,175 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.45
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1147789263
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010846019534, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1147789264}
+  m_Layer: 0
+  m_Name: GrabPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1147789264
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012028070890, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1147789263}
+  m_LocalRotation: {x: -0.7378538, y: 0.120194316, z: 0.13424167, w: 0.6504647}
+  m_LocalPosition: {x: 0.16474305, y: 0.062239647, z: 0.25752535}
+  m_LocalScale: {x: 1.0000004, y: 1.0000004, z: 1.0000007}
+  m_Children: []
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: -360, z: 0}
+--- !u!1 &1158073986
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1158073987}
+  - component: {fileID: 1158073989}
+  - component: {fileID: 1158073988}
+  m_Layer: 0
+  m_Name: Give thumbs up to continue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1158073987
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158073986}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1158073988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158073986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 715153d525c322e47890cc24adb976b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 225111328}
+  transitionState: {fileID: 222778846}
+  withinAngle: 70
+  forDuration: 1
+--- !u!114 &1158073989
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158073986}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: SetText
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: Give me the thumbs up when you are ready to move on!
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+--- !u!1 &1159817117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1159817118}
+  m_Layer: 0
+  m_Name: Thickness Slider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1159817118
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1159817117}
+  m_LocalRotation: {x: 0.0000001459848, y: -0.000000048428767, z: -0.000000026077029,
+    w: 1}
+  m_LocalPosition: {x: -0.22666438, y: 0.010001662, z: 1.7566657}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2130400786}
+  - {fileID: 809709092}
+  m_Father: {fileID: 616489409}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1163955906
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1188521611849392, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1163955907}
+  m_Layer: 0
+  m_Name: Color Swatch (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1163955907
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4353095884955208, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1163955906}
+  m_LocalRotation: {x: -2.1605053e-14, y: -0.00000007375698, z: 0.000000031610053,
+    w: 1}
+  m_LocalPosition: {x: 1.0200058, y: 0.09999058, z: -1.8599991}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 863751456}
+  - {fileID: 1119727644}
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!43 &1164692778
 Mesh:
   m_ObjectHideFlags: 3
@@ -14991,6 +23546,11 @@ Prefab:
       propertyPath: soundEffect._clips.Array.size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4000013939052844, guid: c915520bed265f24c95aebc38ee51557, type: 2}
       propertyPath: m_LocalPosition.x
       value: 2.10001
@@ -15085,6 +23645,31 @@ Prefab:
       value: 
       objectReference: {fileID: 243000011340830754, guid: 43de2443e9a4ff54e842fdf9d3168906,
         type: 2}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1840705451}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: NotifyColorPalleteTouched
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c915520bed265f24c95aebc38ee51557, type: 2}
   m_IsPrefabParent: 0
@@ -15104,6 +23689,189 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1166750748}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &1171800793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1500434227483828, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1171800794}
+  m_Layer: 0
+  m_Name: Color Swatch (17)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1171800794
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4394252034929414, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1171800793}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 2.116311, y: 2.6, z: -0.78}
+  m_LocalScale: {x: 0.3872106, y: 0.38720962, z: 0.38720992}
+  m_Children:
+  - {fileID: 1398720418}
+  - {fileID: 1289074361}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1172146389
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1699192299431742, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1172146390}
+  m_Layer: 0
+  m_Name: Color Swatch (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1172146390
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4987360506643914, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1172146389}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 2.9570885, y: 1.11, z: -0.64}
+  m_LocalScale: {x: 0.38720986, y: 0.38720933, z: 0.38720956}
+  m_Children:
+  - {fileID: 402761982}
+  - {fileID: 1269896763}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1174988836
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010310728758, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1174988837}
+  m_Layer: 5
+  m_Name: Wearable Menu Anchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1174988837
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000013067875132, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1174988836}
+  m_LocalRotation: {x: -0.76604474, y: -0.014767475, z: -0.01803148, w: -0.64236456}
+  m_LocalPosition: {x: -0.073, y: 0.001, z: 0.101}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1249890665}
+  m_Father: {fileID: 1372450353}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 100.406006, y: -14.677002, z: -14.411987}
+--- !u!1 &1175529918
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1175529919}
+  - component: {fileID: 1175529921}
+  - component: {fileID: 1175529920}
+  m_Layer: 0
+  m_Name: Button Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1175529919
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1175529918}
+  m_LocalRotation: {x: 0, y: -0.7069895, z: 0.707224, w: 0}
+  m_LocalPosition: {x: 0.006, y: 0.4, z: 0.027}
+  m_LocalScale: {x: 0.1014021, y: 0.101402156, z: 0.101402156}
+  m_Children: []
+  m_Father: {fileID: 1478040350}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 89.981, y: 0, z: 180}
+--- !u!102 &1175529920
+TextMesh:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1175529918}
+  m_Text: 'Coming
+
+    soon!'
+  m_OffsetZ: 0
+  m_CharacterSize: 1
+  m_LineSpacing: 1
+  m_Anchor: 4
+  m_Alignment: 1
+  m_TabSize: 4
+  m_FontSize: 47
+  m_FontStyle: 0
+  m_RichText: 1
+  m_Font: {fileID: 12800000, guid: cd2b86fdeb787f84698ee40d32de9350, type: 3}
+  m_Color:
+    serializedVersion: 2
+    rgba: 4287072135
+--- !u!23 &1175529921
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1175529918}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 89e1f0dde257b3c45a5f0b5574299f85, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1001 &1175783711
 Prefab:
   m_ObjectHideFlags: 0
@@ -15276,6 +24044,78 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 991e646c5ab23d14fa8790a91df19318, type: 3}
   m_PrefabInternal: {fileID: 1177432143}
+--- !u!1 &1184242366
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1184242367}
+  - component: {fileID: 1184242369}
+  - component: {fileID: 1184242368}
+  m_Layer: 0
+  m_Name: Button Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1184242367
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1184242366}
+  m_LocalRotation: {x: 0, y: -0.7069895, z: 0.707224, w: 0}
+  m_LocalPosition: {x: -0, y: 0.4, z: -0}
+  m_LocalScale: {x: 1.4188225, y: 1.4188229, z: 1.4188229}
+  m_Children: []
+  m_Father: {fileID: 1455894659}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 89.981, y: 0, z: 180}
+--- !u!23 &1184242368
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1184242366}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: ee3cc47f6f35c064e819c8049e1cd56b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1184242369
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1184242366}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1185104849
 GameObject:
   m_ObjectHideFlags: 0
@@ -15334,6 +24174,82 @@ MonoBehaviour:
   scaleLastFingerBone: 0
   modelFingerPointing: {x: 1, y: 0, z: 0}
   modelPalmFacing: {x: 0, y: -1, z: 0}
+--- !u!1 &1186674470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1416001293227308, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1186674471}
+  - component: {fileID: 1186674473}
+  - component: {fileID: 1186674472}
+  m_Layer: 0
+  m_Name: Mixing Basin Model
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1186674471
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4769393009092796, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1186674470}
+  m_LocalRotation: {x: -6.123234e-17, y: 1, z: 6.123234e-17, w: -3.7493994e-33}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.4777262, y: 0.42220747, z: 1.4777262}
+  m_Children: []
+  m_Father: {fileID: 1509140293}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1186674472
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23470647315350052, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1186674470}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e4be46ae886dfe046964e3c525541384, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1186674473
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33618820821131650, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1186674470}
+  m_Mesh: {fileID: 4300000, guid: 224b0c2601c67cc46871bb1c660ef3d8, type: 3}
 --- !u!1 &1188845597
 GameObject:
   m_ObjectHideFlags: 0
@@ -15380,6 +24296,288 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DeactivateOnDisable: 0
   Transition: {fileID: 0}
+--- !u!1 &1191132582
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1272512768210444, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1191132583}
+  - component: {fileID: 1191132585}
+  - component: {fileID: 1191132584}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1191132583
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4630999913946508, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1191132582}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.083228126, y: 0.2795346, z: 0.052579373}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 790923305}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1191132584
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23405318498490936, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1191132582}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1191132585
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33638562130313962, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1191132582}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1191593141
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1191593142}
+  - component: {fileID: 1191593143}
+  m_Layer: 0
+  m_Name: End
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1191593142
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1191593141}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 34
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1191593143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1191593141}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: ClearText
+            m_Mode: 1
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: 
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+--- !u!1 &1194378813
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1223116310905566, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1194378814}
+  m_Layer: 0
+  m_Name: Cleaning Basin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1194378814
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4563634438631618, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1194378813}
+  m_LocalRotation: {x: -0.34188542, y: -0.61896235, z: -0.61896235, w: 0.34188533}
+  m_LocalPosition: {x: 0, y: -0.78, z: 2.44}
+  m_LocalScale: {x: 0.00999999, y: 0.00999999, z: 0.014374971}
+  m_Children:
+  - {fileID: 237921212}
+  - {fileID: 887154784}
+  m_Father: {fileID: 2010003633}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: -90.019, y: -180, z: 57.721992}
+--- !u!1 &1201317456
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1375238368205810, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1201317457}
+  - component: {fileID: 1201317459}
+  - component: {fileID: 1201317458}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1201317457
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4151890066644664, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1201317456}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.15894048, y: 0.036106657, z: -0.2440705}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 2052765576}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1201317458
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23422927647052822, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1201317456}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1201317459
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33794465268985208, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1201317456}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1201817528
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000012789622858, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1201817529}
+  m_Layer: 0
+  m_Name: HandAttachments_L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1201817529
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012553425574, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1201817528}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1372450353}
+  - {fileID: 483099618}
+  - {fileID: 1244345307}
+  - {fileID: 606411737}
+  - {fileID: 445224930}
+  - {fileID: 1941339941}
+  - {fileID: 250519633}
+  - {fileID: 955697615}
+  - {fileID: 451462310}
+  m_Father: {fileID: 1293942366}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1207691028
 GameObject:
   m_ObjectHideFlags: 0
@@ -15596,6 +24794,36 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1209058330}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1217729001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000012591613480, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1217729002}
+  m_Layer: 0
+  m_Name: Thumb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1217729002
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000010398614092, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1217729001}
+  m_LocalRotation: {x: 0.5637837, y: -0.34934276, z: -0.6644454, w: -0.34441242}
+  m_LocalPosition: {x: -0.27953178, y: 1.5131431, z: 1.2896092}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1221208311
 GameObject:
   m_ObjectHideFlags: 0
@@ -15698,6 +24926,39 @@ MonoBehaviour:
       m_Calls: []
     m_TypeName: UnityEngine.UI.ScrollRect+ScrollRectEvent, UnityEngine.UI, Version=1.0.0.0,
       Culture=neutral, PublicKeyToken=null
+--- !u!1 &1222972608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1695369967872638, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1222972609}
+  m_Layer: 0
+  m_Name: Color Swatch (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1222972609
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4019839623046718, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1222972608}
+  m_LocalRotation: {x: -7.400445e-15, y: -0.000000010536694, z: -0.000000031610167,
+    w: 1}
+  m_LocalPosition: {x: 1.0200065, y: -0, z: 1.8699887}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 806411398}
+  - {fileID: 934590210}
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1223683452
 GameObject:
   m_ObjectHideFlags: 0
@@ -15900,6 +25161,34 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DeactivateOnDisable: 1
   Transition: {fileID: 0}
+--- !u!1 &1230328467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1230328468}
+  m_Layer: 0
+  m_Name: PinkyDistalJoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1230328468
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1230328467}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0000000060535963, y: -0.000000028235913, z: 0.018110007}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1544470583}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1231586758
 GameObject:
   m_ObjectHideFlags: 0
@@ -16002,6 +25291,36 @@ Transform:
   m_Father: {fileID: 658501598}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1244345306
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011686171552, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1244345307}
+  m_Layer: 0
+  m_Name: Thumb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1244345307
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000011146630986, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1244345306}
+  m_LocalRotation: {x: -0.5637806, y: -0.3493443, z: -0.6644481, w: 0.34441075}
+  m_LocalPosition: {x: 0.27951926, y: 1.5131431, z: 1.2896117}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1248161183
 GameObject:
   m_ObjectHideFlags: 0
@@ -16030,6 +25349,82 @@ Transform:
   m_Father: {fileID: 1847961897}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: -0.418, y: 175.11401, z: -7.117}
+--- !u!1 &1249890664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000014286133064, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1249890665}
+  - component: {fileID: 1249890667}
+  - component: {fileID: 1249890666}
+  m_Layer: 0
+  m_Name: Attachment Ring
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1249890665
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012530090064, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1249890664}
+  m_LocalRotation: {x: -0, y: -0, z: -9.313227e-10, w: 1}
+  m_LocalPosition: {x: 0.0002, y: 0.0019, z: 0}
+  m_LocalScale: {x: 2.0256948, y: 2.0256953, z: 2.0256953}
+  m_Children: []
+  m_Father: {fileID: 1174988837}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -185.31, y: 0, z: 180}
+--- !u!23 &1249890666
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23000010185471664, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1249890664}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1249890667
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33000012982707688, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1249890664}
+  m_Mesh: {fileID: 4300000, guid: bb552b845e1247e4b96d83b9c9bd0207, type: 3}
 --- !u!1 &1255518558
 GameObject:
   m_ObjectHideFlags: 0
@@ -16186,6 +25581,258 @@ Transform:
   m_Father: {fileID: 663620330}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1258465589
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1974130647588816, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1258465590}
+  - component: {fileID: 1258465592}
+  - component: {fileID: 1258465591}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1258465590
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4604941805449692, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1258465589}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.19082923, y: -0.00926501, z: 0.39897618}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 30071809}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1258465591
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23536163055753170, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1258465589}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1258465592
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33499729114739930, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1258465589}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1259462721
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1315479071886288, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1259462722}
+  - component: {fileID: 1259462726}
+  - component: {fileID: 1259462725}
+  - component: {fileID: 1259462724}
+  - component: {fileID: 1259462723}
+  m_Layer: 0
+  m_Name: Thick Ribbon Renderer (circle)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1259462722
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4200987617497462, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1259462721}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0.0000023990867}
+  m_LocalPosition: {x: -0, y: 0.559, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 137824214}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1259462723
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114913891726267932, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1259462721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a556b57af5586b4dbefb616d1d34b4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 11400000, guid: c96ef0e4a09215047bec2470b679f3ec, type: 2}
+  clipTime: 29.266666
+--- !u!114 &1259462724
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114625929350600168, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1259462721}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41ee06f17d023954c9ea5105af0e174a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _ribbonMaterial: {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  _finalizedRibbonParent: {fileID: 181722600}
+  registerWithHistoryManager: 0
+--- !u!33 &1259462725
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33343224749167078, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1259462721}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1259462726
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23385238376784644, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1259462721}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1 &1260164692
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1260164693}
+  - component: {fileID: 1260164695}
+  - component: {fileID: 1260164694}
+  m_Layer: 0
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1260164693
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1260164692}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1955089286}
+  m_Father: {fileID: 959373736}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1260164694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1260164692}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.8455882, g: 0.8455882, b: 0.8455882, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+--- !u!222 &1260164695
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1260164692}
 --- !u!1 &1261011970
 GameObject:
   m_ObjectHideFlags: 0
@@ -16215,6 +25862,158 @@ Transform:
   m_Father: {fileID: 1255518562}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1261024189
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1892185239530596, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1261024190}
+  - component: {fileID: 1261024192}
+  - component: {fileID: 1261024191}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1261024190
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4724390601410606, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1261024189}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.050694898, y: 0.010131814, z: -0.02196916}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1101815129}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1261024191
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23611416178312500, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1261024189}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1261024192
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33366678844071490, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1261024189}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1269896762
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1892929044233780, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1269896763}
+  - component: {fileID: 1269896765}
+  - component: {fileID: 1269896764}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1269896763
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4051047885975026, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1269896762}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.1419104, y: 0.4777348, z: 0.34473428}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1172146390}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1269896764
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23409195898313188, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1269896762}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1269896765
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33867915332234208, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1269896762}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1001 &1270007549
 Prefab:
   m_ObjectHideFlags: 0
@@ -16369,6 +26168,72 @@ Transform:
   m_Father: {fileID: 1806797255}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1276157320
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1536610378}
+    m_Modifications:
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Name
+      value: Button Surface
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &1276157321 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_PrefabInternal: {fileID: 1276157320}
 --- !u!1001 &1277933609
 Prefab:
   m_ObjectHideFlags: 0
@@ -16498,6 +26363,124 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1277933609}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1001 &1281404667
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1293942366}
+    m_Modifications:
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000115202326
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: -0.00000011520231
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: _showArm
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: _material
+      value: 
+      objectReference: {fileID: 2100000, guid: ebee5ae2a6fa28f408e229c68f7a0686, type: 2}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: _sphereMesh
+      value: 
+      objectReference: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: _cylinderResolution
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: _materialNonGhostable
+      value: 
+      objectReference: {fileID: 2100000, guid: ebee5ae2a6fa28f408e229c68f7a0686, type: 2}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: _materialGhostable
+      value: 
+      objectReference: {fileID: 2100000, guid: f27d4128aba1059498d9e8ecb5c428b3, type: 2}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: useGhostable
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1281404668 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+  m_PrefabInternal: {fileID: 1281404667}
+--- !u!114 &1281404669 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3,
+    type: 2}
+  m_PrefabInternal: {fileID: 1281404667}
+  m_Script: {fileID: 11500000, guid: a04122797dd84ca43a07055f12d91e0f, type: 3}
+--- !u!1 &1282821178
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1868184095091222, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1282821179}
+  m_Layer: 0
+  m_Name: Color Palette
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1282821179
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4146997237737922, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1282821178}
+  m_LocalRotation: {x: 0.70615155, y: 0.043537263, z: -0.043489784, w: 0.70538163}
+  m_LocalPosition: {x: -1.97, y: 0.932, z: 0.563}
+  m_LocalScale: {x: 0.40706554, y: 0.40706477, z: 0.40706465}
+  m_Children:
+  - {fileID: 1592325210}
+  - {fileID: 1222972609}
+  - {fileID: 1414023800}
+  - {fileID: 1025233048}
+  - {fileID: 2052765576}
+  - {fileID: 114110166}
+  - {fileID: 1163955907}
+  - {fileID: 103874079}
+  m_Father: {fileID: 63207537}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1284692830
 GameObject:
   m_ObjectHideFlags: 0
@@ -16683,6 +26666,111 @@ MonoBehaviour:
   parent: {fileID: 1284692833}
   space: {fileID: 1284692833}
   _radius: 0.1
+--- !u!1 &1289074360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1852998424299090, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1289074361}
+  - component: {fileID: 1289074363}
+  - component: {fileID: 1289074362}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1289074361
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4007618081578866, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1289074360}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.20940566, y: 0.622238, z: 0.65468514}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1171800794}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1289074362
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23386074588163958, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1289074360}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1289074363
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33585646146434096, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1289074360}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1289417878
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1289417879}
+  m_Layer: 5
+  m_Name: Icon Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1289417879
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1289417878}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.7, y: 0.7, z: 0.7}
+  m_Children:
+  - {fileID: 1889300877}
+  m_Father: {fileID: 572014665}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1291044481
 GameObject:
   m_ObjectHideFlags: 0
@@ -16739,6 +26827,60 @@ Material:
     m_Floats: []
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &1293942365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 166928, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1293942366}
+  - component: {fileID: 1293942367}
+  m_Layer: 0
+  m_Name: HandModels
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1293942366
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 483344, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1293942365}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1702601571}
+  - {fileID: 1281404668}
+  - {fileID: 1201817529}
+  - {fileID: 109013843}
+  m_Father: {fileID: 1311336093}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1293942367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1293942365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c592f16851a620743868a31232613370, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _leapProvider: {fileID: 94561690}
+  ModelPool:
+  - GroupName: Capsule Hands
+    _handModelManager: {fileID: 0}
+    LeftModel: {fileID: 1702601572}
+    IsLeftToBeSpawned: 0
+    RightModel: {fileID: 1281404669}
+    IsRightToBeSpawned: 0
+    IsEnabled: 1
+    CanDuplicate: 0
 --- !u!1 &1295621216
 GameObject:
   m_ObjectHideFlags: 0
@@ -16767,6 +26909,82 @@ Transform:
   m_Father: {fileID: 1914107079}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: -41.750004, y: 179.99998, z: 0}
+--- !u!1 &1304375781
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1408856325321618, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1304375782}
+  - component: {fileID: 1304375784}
+  - component: {fileID: 1304375783}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1304375782
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4876490534932142, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1304375781}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.083228126, y: 0.2795346, z: 0.052579373}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 790923305}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1304375783
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23050475303933798, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1304375781}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1304375784
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33096411861648454, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1304375781}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &1306173171
 GameObject:
   m_ObjectHideFlags: 0
@@ -16839,6 +27057,40 @@ BoxCollider:
   serializedVersion: 2
   m_Size: {x: 1, y: 1, z: 1}
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1311336092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 167028, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1311336093}
+  m_Layer: 0
+  m_Name: LMHeadMountedRig
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1311336093
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 414974, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1311336092}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0.0000023990867}
+  m_LocalPosition: {x: 0, y: -0.559, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1555422911}
+  - {fileID: 94561691}
+  - {fileID: 1293942366}
+  - {fileID: 206834522}
+  - {fileID: 137824214}
+  - {fileID: 650284665}
+  m_Father: {fileID: 1649983740}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: -180.00002, z: 0}
 --- !u!1 &1317661674
 GameObject:
   m_ObjectHideFlags: 0
@@ -17101,7 +27353,7 @@ Transform:
   - {fileID: 948901544}
   - {fileID: 473414029}
   m_Father: {fileID: 1046230652}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 104.061005, y: -146.556, z: -147.789}
 --- !u!114 &1325899578
 MonoBehaviour:
@@ -17127,6 +27379,342 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &1329487790
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1585471058417420, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1329487791}
+  - component: {fileID: 1329487793}
+  - component: {fileID: 1329487792}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1329487791
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4958388589091496, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1329487790}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.109879375, y: 0.20479386, z: 0.01872692}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 752051449}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1329487792
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23756230133190418, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1329487790}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1329487793
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33343359481460770, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1329487790}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1330166008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1243906676136182, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1330166009}
+  - component: {fileID: 1330166011}
+  - component: {fileID: 1330166010}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1330166009
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4601839247390138, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1330166008}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.11861151, y: 0.2515289, z: 0.21232267}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1445655200}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1330166010
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23485530185306374, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1330166008}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1330166011
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33545591494311040, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1330166008}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1332202001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1518962100427868, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1332202002}
+  - component: {fileID: 1332202004}
+  - component: {fileID: 1332202003}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1332202002
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4144396771218428, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1332202001}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.0026242884, y: 0.507657, z: -0.11423433}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 103874079}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1332202003
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23542952032342876, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1332202001}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1332202004
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33369341645322838, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1332202001}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1334572879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1913956358866150, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1334572880}
+  - component: {fileID: 1334572882}
+  - component: {fileID: 1334572881}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1334572880
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4966074320640690, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1334572879}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.081978664, y: 0.36504805, z: 0.28296733}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1513574475}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1334572881
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23673425944935374, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1334572879}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1334572882
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33289928396353728, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1334572879}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1341977916
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1989702330956296, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1341977917}
+  m_Layer: 0
+  m_Name: Color Swatch (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1341977917
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4215932000451780, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1341977916}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -1.7713203, y: 0.38, z: -0.57}
+  m_LocalScale: {x: 0.38720986, y: 0.38720933, z: 0.38720956}
+  m_Children:
+  - {fileID: 721232895}
+  - {fileID: 305711193}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1342523219
 GameObject:
   m_ObjectHideFlags: 0
@@ -17199,152 +27787,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1342523219}
   m_Mesh: {fileID: 4300002, guid: 0a9012ddf2f259d4386c58e70758bd33, type: 3}
---- !u!43 &1348381171
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Ribbon Circle Mesh
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 1536
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 256
-    localAABB:
-      m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-      m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
-  m_Skin: []
-  m_VertexData:
-    serializedVersion: 2
-    m_VertexCount: 256
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 6144
-    _typelessdata: d9cef73c6f12833900000000a681353fa881343f67393ebc45b6f33c6f128339000000003e8034bf1e83353f822e3dbcd9cef73c6f1283b900000000a681353fa88134bf233d3e3c45b6f33c6f1283b9000000003e8034bf1e8335bfbb2a3d3c5e9df63c6f128339c15042bb5d57343f9c81343f59fda5bdd889f23c6f128339871a3fbbf2eb33bf1383353f8d026c3d5e9df63c6f1283b9c15042bb87ec343f9c8134bf5c536dbdd889f23c6f1283b9871a3fbb9b5733bf148335bf0912a53de30bf33c6f1283393861c1bb6270313fa581343f2a4d19be7507ef3c6f128339f42ebebbfb9b31bf1e83353f8c42013ee30bf33c6f1283b93861c1bb4699323fa58134bfd2fa01be7507ef3c6f1283b9f42ebebbbf7430bf1e8335bfb973183e3023ed3c6f128339a6de0fbc02d42c3f9e81343fa2215ebec437e93c6f128339e07d0dbc39962dbf1683353fc745463e3023ed3c6f1283b9a6de0fbcc48d2e3f9c8134bf956047bec437e93c6f1283b9e07d0dbce9de2bbf188335bf9de65c3edaf1e43c6f128339fea93dbc7e8d263fa281343f476990be1829e13c6f12833972873abc71e427bf1983353f17b0843edaf1e43c6f1283b9fea93dbcded3283fa08134bf4f6d85be1829e13c6f1283b972873abc49a125bf198335bf759c8f3e108cda3c6f128339bba169bc64ac1e3f9d81343fa95db0be4eefd63c6f12833923c565bcc89420bf1083353f37f6a43e108cda3c6f1283b9bba169bcc579213f988134bf79e1a5be4eefd63c6f1283b923c565bc5dcb1dbf158335bf8c63af3e790bce3c6f128339bbac89bc1544153f9b81343f3d9fcebe9da3ca3c6f1283392d6687bc24b917bf1d83353f86a5c33e790bce3c6f1283b9bbac89bc8591183fa78134bf84bcc4be9da3ca3c6f1283b92d6687bc647014bf128335bf427acd3ee48ebf3c6f1283392d359dbcb06b0a3fac81343f5ee3eabe5464bc3c6f128339f79b9abc7a670dbf2183353f8d72e03ee48ebf3c6f1283b92d359dbc22310e3fa88134bfa0b2e1be5464bc3c6f1283b9f79b9abc65a709bf268335bf3a96e93e093aaf3c6f128339083aafbc567cfc3e9f81343f3b7202bf9554ac3c6f1283399454acbc3eb901bf1783353f3e16fb3e093aaf3c6f1283b9083aafbc3b72023f9f8134bf567cfcbe9554ac3c6f1283b99454acbc3d16fbbe178335bf3eb9013f2e359d3c6f128339e38ebfbca0b2e13ea981343f23310ebff89b9a3c6f1283395364bcbc3a96e9be2683353f64a7093f2e359d3c6f1283b9e38ebfbc5ee3ea3eac8134bfb06b0abff89b9a3c6f1283b95364bcbc8d72e0be218335bf7a670d3fbcac893c6f128339780bcebc80bcc43ea581343f859118bf2e66873c6f1283399ca3cabc3f7acdbe1283353f6470143fbcac893c6f1283b9780bcebc3b9fce3e9b8134bf144415bf2e66873c6f1283b99ca3cabc86a5c3be1d8335bf27b9173fbca1693c6f1283390f8cdabc78e1a53e9a81343fc67921bf24c5653c6f1283394defd6bc8963afbe1483353f5ecb1d3fbca1693c6f1283b90f8cdabca75db03e9c8134bf64ac1ebf24c5653c6f1283b94defd6bc36f6a4be108335bfc794203fffa93d3c6f128339d9f1e4bc506d853ea081343fddd328bf73873a3c6f1283391729e1bc769c8fbe1983353f49a1253fffa93d3c6f1283b9d9f1e4bc4869903ea18134bf7d8d26bf73873a3c6f1283b91729e1bc18b084be198335bf70e4273fa8de0f3c6f1283392f23edbc9760473e9c81343fc58d2ebfe27d0d3c6f128339c337e9bc9ee65cbe1883353fe6de2b3fa8de0f3c6f1283b92f23edbca2215e3e9e8134bf01d42cbfe27d0d3c6f1283b9c337e9bcc94546be158335bf39962d3f3c61c13b6f128339e20bf3bce6fa013ea581343f459932bff82ebe3b6f1283397407efbcc27318be1d83353fbe74303f3c61c13b6f1283b9e20bf3bc344d193ea58134bf627031bff82ebe3b6f1283b97407efbca04201be1e8335bffb9b313fca50423b6f1283395e9df6bc34536d3d9b81343f87ec34bf901a3f3b6f128339d889f2bc1e12a5bd1483353f9b57333fca50423b6f1283b95e9df6bc6cfda53d9c8134bf5c5734bf901a3f3b6f1283b9d889f2bc64026cbd138335bff2eb333fea4918316f128339d8cef7bc073a3ebca781343fa68135bf84c515316f12833944b6f3bc5d2b3dbc1e83353f3e80343fea4918316f1283b9d8cef7bc073a3e3ca88134bfa68135bf84c515316f1283b944b6f3bc5d2b3d3c1e8335bf3e80343fb75042bb6f1283395e9df6bc46fda5bd9c81343f5d5734bf7d1a3fbb6f128339d889f2bc40026c3d1283353ff3eb333fb75042bb6f1283b95e9df6bc0d536dbd9b8134bf88ec34bf7d1a3fbb6f1283b9d889f2bcf811a53d168335bf9c57333f3261c1bb6f128339e30bf3bc2b4d19bea581343f627031bfee2ebebb6f1283397507efbc8c42013e1e83353ffb9b313f3261c1bb6f1283b9e30bf3bcd3fa01bea68134bf459932bfee2ebebb6f1283b97507efbcb973183e1d8335bfbe74303fa3de0fbc6f1283393023edbca2215ebe9e81343f02d42cbfdd7d0dbc6f128339c437e9bcc745463e1683353f39962d3fa3de0fbc6f1283b93023edbc956047be9c8134bfc48d2ebfdd7d0dbc6f1283b9c437e9bc9de65c3e188335bfe9de2b3ffba93dbc6f128339daf1e4bc476990bea281343f7e8d26bf6f873abc6f1283391829e1bc17b0843e1983353f71e4273ffba93dbc6f1283b9daf1e4bc4f6d85bea08134bfded328bf6f873abc6f1283b91829e1bc759c8f3e198335bf49a1253fb8a169bc6f128339108cdabca75db0be9c81343f64ac1ebf20c565bc6f1283394eefd6bc36f6a43e1083353fc794203fb8a169bc6f1283b9108cdabc78e1a5be9a8134bfc67921bf20c565bc6f1283b94eefd6bc8b63af3e148335bf5ecb1d3fbaac89bc6f128339790bcebc3c9fcebe9b81343f154415bf2c6687bc6f1283399da3cabc85a5c33e1d83353f26b9173fbaac89bc6f1283b9790bcebc80bcc4bea68134bf859118bf2c6687bc6f1283b99da3cabc3f7acd3e128335bf6470143f2c359dbc6f128339e48ebfbc5be3eabeac81343fb36b0abff69b9abc6f1283395464bcbc8972e03e2283353f79670d3f2c359dbc6f1283b9e48ebfbc9db2e1bea98134bf23310ebff69b9abc6f1283b95464bcbc3696e93e258335bf67a7093f083aafbc6f128339093aafbc3b7202bfa181343f517cfcbe9454acbc6f1283399554acbc3e16fb3e1683353f40b9013f083aafbc6f1283b9093aafbc567cfcbe9c8134bf3e7202bf9454acbc6f1283b99554acbc3eb9013f1a8335bf3816fb3ee28ebfbc6f1283392e359dbc25310ebfa881343f9eb2e1be5264bcbc6f128339f89b9abc66a7093f2783353f3396e93ee28ebfbc6f1283b92e359dbcb36b0abfaf8134bf59e3eabe5264bcbc6f1283b9f89b9abc7b670d3f1f8335bf8a72e03e770bcebc6f128339bcac89bc859118bfa781343f84bcc4be9ba3cabc6f1283392e6687bc6470143f1283353f427acd3e770bcebc6f1283b9bcac89bc154415bf9b8134bf3d9fcebe9ba3cabc6f1283b92e6687bc24b9173f1d8335bf86a5c33e0e8cdabc6f128339bda169bcc57921bf9881343f79e1a5be4cefd6bc6f12833925c565bc5dcb1d3f1583353f8b63af3e0e8cdabc6f1283b9bda169bc64ac1ebf9d8134bfa95db0be4cefd6bc6f1283b925c565bcc794203f108335bf37f6a43ed8f1e4bc6f12833900aa3dbcded328bfa181343f516d85be1629e1bc6f12833974873abc4aa1253f1a83353f779c8f3ed8f1e4bc6f1283b900aa3dbc7d8d26bfa18134bf486990be1629e1bc6f1283b974873abc70e4273f198335bf18b0843e2e23edbc6f128339a9de0fbcc58d2ebf9c81343f976047bec237e9bc6f128339e37d0dbce7de2b3f1983353f9fe65c3e2e23edbc6f1283b9a9de0fbc01d42cbf9e8134bfa2215ebec237e9bc6f1283b9e37d0dbc38962d3f148335bfc745463ee10bf3bc6f1283393e61c1bb459932bfa681343fe7fa01be7307efbc6f128339fa2ebebbbe74303f1d83353fc373183ee10bf3bc6f1283b93e61c1bb627031bfa58134bf354d19be7307efbc6f1283b9fa2ebebbfa9b313f1e8335bfa042013e5d9df6bc6f128339cf5042bb88ec34bf9b81343f35536dbdd789f2bc6f128339951a3fbb9b57333f1583353f1f12a53d5d9df6bc6f1283b9cf5042bb5c5734bf9c8134bf6dfda5bdd789f2bc6f1283b9951a3fbbf3eb333f148335bf67026c3dd7cef7bc6f128339228071b1a68135bfa781343f073a3e3c43b6f3bc6f12833940826db13e80343f1f83353f5e2b3d3cd7cef7bc6f1283b9228071b1a68135bfa78134bf073a3ebc43b6f3bc6f1283b940826db13e80343f1f8335bf5e2b3dbc5d9df6bc6f128339b150423b5c5734bf9c81343f46fda53dd789f2bc6f128339771a3f3bf3eb333f1283353f40026cbd5d9df6bc6f1283b9b150423b88ec34bf9b8134bf0d536d3dd789f2bc6f1283b9771a3f3b9b57333f158335bff611a5bde20bf3bc6f1283392f61c13b637031bfa481343f2a4d193e7407efbc6f128339eb2ebe3bfb9b313f1e83353f8c4201bee20bf3bc6f1283b92f61c13b469932bfa68134bfd3fa013e7407efbc6f1283b9eb2ebe3bbf74303f1e8335bfb97318be2f23edbc6f128339a2de0f3c01d42cbf9e81343fa2215e3ec337e9bc6f128339dc7d0d3c39962d3f1583353fc74546be2f23edbc6f1283b9a2de0f3cc58d2ebf9b8134bf9560473ec337e9bc6f1283b9dc7d0d3ce7de2b3f198335bf9ee65cbed9f1e4bc6f128339f9a93d3c7d8d26bfa081343f4869903e1729e1bc6f1283396d873a3c70e4273f1983353f18b084bed9f1e4bc6f1283b9f9a93d3cded328bfa18134bf516d853e1729e1bc6f1283b96d873a3c4aa1253f1a8335bf779c8fbe0f8cdabc6f128339b6a1693c64ac1ebf9c81343fa75db03e4defd6bc6f1283391ec5653cc794203f1083353f36f6a4be0f8cdabc6f1283b9b6a1693cc57921bf998134bf77e1a53e4defd6bc6f1283b91ec5653c5ecb1d3f148335bf8b63afbe780bcebc6f128339b9ac893c154415bf9b81343f3c9fce3e9ca3cabc6f1283392b66873c27b9173f1e83353f86a5c3be780bcebc6f1283b9b9ac893c859118bfa68134bf80bcc43e9ca3cabc6f1283b92b66873c6470143f128335bf3f7acdbee38ebfbc6f1283392b359d3cb36b0abfac81343f5be3ea3e5364bcbc6f128339f59b9a3c79670d3f2283353f8972e0bee38ebfbc6f1283b92b359d3c23310ebfa98134bf9db2e13e5364bcbc6f1283b9f59b9a3c67a7093f258335bf3696e9be083aafbc6f128339073aaf3c507cfcbea081343f3a72023f9454acbc6f1283399354ac3c40b9013f1683353f3e16fbbe083aafbc6f1283b9073aaf3c3e7202bf9c8134bf567cfc3e9454acbc6f1283b99354ac3c3816fb3e1a8335bf3eb901bf2d359dbc6f128339e18ebf3c9eb2e1bea881343f25310e3ff79b9abc6f1283395164bc3c3296e93e2683353f65a709bf2d359dbc6f1283b9e18ebf3c57e3eabeae8134bfb26b0a3ff79b9abc6f1283b95164bc3c8a72e03e1f8335bf7b670dbfbbac89bc6f128339760bce3c84bcc4bea781343f8591183f2d6687bc6f1283399aa3ca3c427acd3e1283353f647014bfbbac89bc6f1283b9760bce3c3d9fcebe9b8134bf1544153f2d6687bc6f1283b99aa3ca3c86a5c33e1d8335bf24b917bfbba169bc6f1283390d8cda3c79e1a5be9881343fc579213f23c565bc6f1283394befd63c8b63af3e1583353f5dcb1dbfbba169bc6f1283b90d8cda3ca95db0be9d8134bf64ac1e3f23c565bc6f1283b94befd63c37f6a43e108335bfc79420bffea93dbc6f128339d7f1e43c506d85bea081343fddd3283f72873abc6f1283391529e13c769c8f3e1983353f49a125bffea93dbc6f1283b9d7f1e43c486990bea18134bf7d8d263f72873abc6f1283b91529e13c18b0843e198335bf70e427bfa7de0fbc6f1283392d23ed3c976047be9c81343fc58d2e3fe17d0dbc6f128339c137e93c9ee65c3e1883353fe6de2bbfa7de0fbc6f1283b92d23ed3ca2215ebe9e8134bf01d42c3fe17d0dbc6f1283b9c137e93cc945463e158335bf39962dbf3a61c1bb6f128339e00bf33ce7fa01bea681343f4599323ff62ebebb6f1283397207ef3cc373183e1d83353fbe7430bf3a61c1bb6f1283b9e00bf33c354d19bea58134bf6270313ff62ebebb6f1283b97207ef3ca042013e1e8335bffa9b31bfc85042bb6f1283395c9df63c35536dbd9b81343f87ec343f8e1a3fbb6f128339d689f23c2012a53d1583353f9b5733bfc85042bb6f1283b95c9df63c6efda5bd9c8134bf5c57343f8e1a3fbb6f1283b9d689f23c67026c3d148335bff2eb33bf56c011b16f128339d6cef73c083a3e3ca681343fa681353f9a570fb16f12833942b6f33c5e2b3d3c1e83353f3e8034bf56c011b16f1283b9d6cef73c083a3ebca68134bfa681353f9a570fb16f1283b942b6f33c5e2b3dbc1e8335bf3e8034bfb650423b6f1283395c9df63c48fda53d9d81343f5d57343f7c1a3f3b6f128339d689f23c42026cbd1483353ff3eb33bfb650423b6f1283b95c9df63c0f536d3d9b8134bf88ec343f7c1a3f3b6f1283b9d689f23cf811a5bd158335bf9b5733bf3161c13b6f128339e10bf33c2a4d193ea481343f6370313fed2ebe3b6f1283397307ef3c8c4201be1e83353ffb9b31bf3161c13b6f1283b9e10bf33cd3fa013ea68134bf4699323fed2ebe3b6f1283b97307ef3cb97318be1d8335bfbf7430bfa3de0f3c6f1283392e23ed3ca2215e3e9e81343f01d42c3fdd7d0d3c6f128339c237e93cc74546be1583353f39962dbfa3de0f3c6f1283b92e23ed3c9560473e9b8134bfc58d2e3fdd7d0d3c6f1283b9c237e93c9ee65cbe198335bfe7de2bbffaa93d3c6f128339d8f1e43c4869903ea081343f7d8d263f6e873a3c6f1283391629e13c18b084be1983353f70e427bffaa93d3c6f1283b9d8f1e43c506d853ea08134bfddd3283f6e873a3c6f1283b91629e13c769c8fbe198335bf49a125bfb7a1693c6f1283390e8cda3ca95db03e9d81343f64ac1e3f1fc5653c6f1283394cefd63c37f6a4be1083353fc89420bfb7a1693c6f1283b90e8cda3c79e1a53e988134bfc579213f1fc5653c6f1283b94cefd63c8c63afbe158335bf5dcb1dbfb9ac893c6f128339770bce3c3d9fce3e9b81343f1544153f2b66873c6f1283399ba3ca3c86a5c3be1d83353f24b917bfb9ac893c6f1283b9770bce3c84bcc43ea78134bf8591183f2b66873c6f1283b99ba3ca3c427acdbe128335bf647014bf2b359d3c6f128339e28ebf3c54e3ea3eac81343fb56b0a3ff59b9a3c6f1283395264bc3c8872e0be2183353f7c670dbf2b359d3c6f1283b9e28ebf3c9ab2e13ea88134bf24310e3ff59b9a3c6f1283b95264bc3c2f96e9be268335bf69a709bf073aaf3c6f128339083aaf3c3e72023f9f81343f517cfc3e9354ac3c6f1283399454ac3c3916fbbe1983353f40b901bf073aaf3c6f1283b9083aaf3c517cfc3e9f8134bf3e72023f9354ac3c6f1283b99454ac3c40b901bf178335bf3816fbbee18ebf3c6f1283392c359d3c24310e3fa881343f99b2e13e5164bc3c6f128339f69b9a3c68a709bf2583353f2f96e9bee18ebf3c6f1283b92c359d3cb56b0a3fac8134bf54e3ea3e5164bc3c6f1283b9f69b9a3c7b670dbf218335bf8772e0be760bce3c6f128339baac893c8591183fa781343f84bcc43e9aa3ca3c6f1283392c66873c647014bf1283353f427acdbe760bce3c6f1283b9baac893c1544153f9b8134bf3d9fce3e9aa3ca3c6f1283b92c66873c24b917bf1d8335bf86a5c3be0d8cda3c6f128339b9a1693cc579213f9881343f79e1a53e4befd63c6f12833921c5653c5dcb1dbf1583353f8b63afbe0d8cda3c6f1283b9b9a1693c64ac1e3f9d8134bfa95db03e4befd63c6f1283b921c5653cc79420bf108335bf37f6a4bed7f1e43c6f128339fca93d3cded3283fa181343f516d853e1529e13c6f12833970873a3c4aa125bf1a83353f779c8fbed7f1e43c6f1283b9fca93d3c7d8d263fa18134bf4869903e1529e13c6f1283b970873a3c70e427bf198335bf18b084be2d23ed3c6f128339a5de0f3cc58d2e3f9c81343f9760473ec137e93c6f128339df7d0d3ce7de2bbf1983353f9fe65cbe2d23ed3c6f1283b9a5de0f3c01d42c3f9e8134bfa2215e3ec137e93c6f1283b9df7d0d3c38962dbf148335bfc74546bee00bf33c6f1283393661c13b4599323fa681343fe7fa013e7207ef3c6f128339f22ebe3bbe7430bf1d83353fc37318bee00bf33c6f1283b93661c13b6270313fa58134bf354d193e7207ef3c6f1283b9f22ebe3bfa9b31bf1e8335bfa04201be5c9df63c6f128339c050423b87ec343f9b81343f25546d3dd689f23c6f128339861a3f3b9a5733bf1483353f5a12a5bd5c9df63c6f1283b9c050423b5b57343f9c8134bfa9fda53dd689f23c6f1283b9861a3f3bf1eb33bf138335bf57036cbd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-    m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!1001 &1348947182
 Prefab:
   m_ObjectHideFlags: 0
@@ -17613,6 +28055,78 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300002, guid: 0a969de86108bb448bd93c6901920346,
     type: 3}
   m_PrefabInternal: {fileID: 1352917712}
+--- !u!1 &1354981792
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1354981793}
+  - component: {fileID: 1354981795}
+  - component: {fileID: 1354981794}
+  m_Layer: 0
+  m_Name: Sphere
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1354981793
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1354981792}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0016999966, y: 0.00960001, z: -0.025599957}
+  m_LocalScale: {x: 0.012056084, y: 0.012056082, z: 0.012056082}
+  m_Children: []
+  m_Father: {fileID: 47246601}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1354981794
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1354981792}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1354981795
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1354981792}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1358029904
 GameObject:
   m_ObjectHideFlags: 0
@@ -17756,6 +28270,11 @@ Prefab:
       propertyPath: soundEffect._clips.Array.size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4000013939052844, guid: c915520bed265f24c95aebc38ee51557, type: 2}
       propertyPath: m_LocalPosition.x
       value: -1.1000069
@@ -17850,6 +28369,31 @@ Prefab:
       value: 
       objectReference: {fileID: 243000011340830754, guid: 43de2443e9a4ff54e842fdf9d3168906,
         type: 2}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1840705451}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: NotifyColorPalleteTouched
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c915520bed265f24c95aebc38ee51557, type: 2}
   m_IsPrefabParent: 0
@@ -17869,6 +28413,148 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1367667443}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &1372450352
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000013584920700, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1372450353}
+  m_Layer: 0
+  m_Name: Palm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1372450353
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000011642593896, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1372450352}
+  m_LocalRotation: {x: -0.8627296, y: -0.075480185, z: -0.12941155, w: 0.48296273}
+  m_LocalPosition: {x: 0.21999401, y: 1.4704567, z: 1.2404597}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 130672513}
+  - {fileID: 707347}
+  - {fileID: 540152223}
+  - {fileID: 364573460}
+  - {fileID: 1174988837}
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1373135254
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1315479071886288, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1373135255}
+  - component: {fileID: 1373135259}
+  - component: {fileID: 1373135258}
+  - component: {fileID: 1373135257}
+  - component: {fileID: 1373135256}
+  m_Layer: 0
+  m_Name: Thick Ribbon Renderer (face)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1373135255
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4200987617497462, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373135254}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0.0000023990867}
+  m_LocalPosition: {x: 0, y: 0.559, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 137824214}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1373135256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114913891726267932, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373135254}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a556b57af5586b4dbefb616d1d34b4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 11400000, guid: 5f8a05c1facfa1c4a8e5b4b3a454a338, type: 2}
+  clipTime: 29.266666
+--- !u!114 &1373135257
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114625929350600168, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373135254}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41ee06f17d023954c9ea5105af0e174a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _ribbonMaterial: {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  _finalizedRibbonParent: {fileID: 181722600}
+  registerWithHistoryManager: 0
+--- !u!33 &1373135258
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33343224749167078, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373135254}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1373135259
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23385238376784644, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373135254}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &1373145395
 GameObject:
   m_ObjectHideFlags: 0
@@ -17927,6 +28613,188 @@ MonoBehaviour:
   scaleLastFingerBone: 0
   modelFingerPointing: {x: 1, y: 0, z: 0}
   modelPalmFacing: {x: 0, y: -1, z: 0}
+--- !u!1 &1373595204
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1373595205}
+  m_Layer: 0
+  m_Name: PinkyMiddleJoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1373595205
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373595204}
+  m_LocalRotation: {x: -0, y: -0, z: -0.000000001396984, w: 1}
+  m_LocalPosition: {x: 0.000000003259629, y: -0.00000012665987, z: 0.032739878}
+  m_LocalScale: {x: 1, y: 1.0000005, z: 1.0000006}
+  m_Children:
+  - {fileID: 1642519555}
+  - {fileID: 623977230}
+  m_Father: {fileID: 1864714347}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1374220060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1648721218548382, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1374220061}
+  - component: {fileID: 1374220063}
+  - component: {fileID: 1374220062}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1374220061
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4097103598313646, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1374220060}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.25805, y: 0.15943469, z: 0.83403045}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 504093782}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1374220062
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23062310890185228, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1374220060}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1374220063
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33515093635948344, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1374220060}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1376903706
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1504683368227322, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1376903707}
+  - component: {fileID: 1376903709}
+  - component: {fileID: 1376903708}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1376903707
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4731579134524970, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1376903706}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.106083125, y: 0.38920316, z: 0.22493535}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 552670153}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1376903708
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23804305163200004, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1376903706}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1376903709
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33735642804441918, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1376903706}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &1385638902
 GameObject:
   m_ObjectHideFlags: 0
@@ -17954,7 +28822,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 573826044}
-  m_RootOrder: 9
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1385638904
 MonoBehaviour:
@@ -18041,6 +28909,82 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 1387595490}
+--- !u!1 &1398720417
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1474309638967238, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1398720418}
+  - component: {fileID: 1398720420}
+  - component: {fileID: 1398720419}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1398720418
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4921495137022670, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1398720417}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.08992563, y: 0.6054296, z: 0.67932814}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1171800794}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1398720419
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23327354719210348, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1398720417}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1398720420
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33712076638721896, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1398720417}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &1400439760
 GameObject:
   m_ObjectHideFlags: 0
@@ -18210,6 +29154,10 @@ Prefab:
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: _showArm
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
   m_IsPrefabParent: 0
@@ -18348,6 +29296,38 @@ AudioSource:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 0
+--- !u!1 &1414023799
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1803850298282032, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1414023800}
+  m_Layer: 0
+  m_Name: Color Swatch (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1414023800
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4975258284217490, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1414023799}
+  m_LocalRotation: {x: -2.1608176e-14, y: -0.00000004214684, z: -0, w: 1}
+  m_LocalPosition: {x: -1.1000067, y: 0.099991664, z: 1.8699889}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1938912149}
+  - {fileID: 307408445}
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1416983840
 GameObject:
   m_ObjectHideFlags: 0
@@ -18419,6 +29399,82 @@ SphereCollider:
   serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
+--- !u!1 &1417739365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1283487481453930, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1417739366}
+  - component: {fileID: 1417739368}
+  - component: {fileID: 1417739367}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1417739366
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4262510145641286, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1417739365}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.008269638, y: 0.76347494, z: -0.07420968}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 552670153}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1417739367
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23033418035295372, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1417739365}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1417739368
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33168626057890482, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1417739365}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &1419264780
 GameObject:
   m_ObjectHideFlags: 0
@@ -18568,6 +29624,82 @@ MonoBehaviour:
   _horizontalAlignment: 1
   _verticalAlignment: 0
   _color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &1429124828
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000014286133064, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1429124829}
+  - component: {fileID: 1429124831}
+  - component: {fileID: 1429124830}
+  m_Layer: 0
+  m_Name: Attachment Ring
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1429124829
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012530090064, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1429124828}
+  m_LocalRotation: {x: -0, y: -0, z: -9.313227e-10, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 2.0256948, y: 2.0256953, z: 2.0256953}
+  m_Children: []
+  m_Father: {fileID: 364573460}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -185.31, y: 0, z: 180}
+--- !u!23 &1429124830
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23000010185471664, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1429124828}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 0
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1429124831
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33000012982707688, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1429124828}
+  m_Mesh: {fileID: 4300000, guid: bb552b845e1247e4b96d83b9c9bd0207, type: 3}
 --- !u!1 &1429411432
 GameObject:
   m_ObjectHideFlags: 0
@@ -18739,152 +29871,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _radius: 1
   _handModel: {fileID: 729865845}
---- !u!43 &1431168179
-Mesh:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Ribbon Circle Mesh
-  serializedVersion: 8
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 1536
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 256
-    localAABB:
-      m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-      m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
-  m_Skin: []
-  m_VertexData:
-    serializedVersion: 2
-    m_VertexCount: 256
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 6144
-    _typelessdata: d9cef73c6f12833900000000a681353fa881343f67393ebc45b6f33c6f128339000000003e8034bf1e83353f822e3dbcd9cef73c6f1283b900000000a681353fa88134bf233d3e3c45b6f33c6f1283b9000000003e8034bf1e8335bfbb2a3d3c5e9df63c6f128339c15042bb5d57343f9c81343f59fda5bdd889f23c6f128339871a3fbbf2eb33bf1383353f8d026c3d5e9df63c6f1283b9c15042bb87ec343f9c8134bf5c536dbdd889f23c6f1283b9871a3fbb9b5733bf148335bf0912a53de30bf33c6f1283393861c1bb6270313fa581343f2a4d19be7507ef3c6f128339f42ebebbfb9b31bf1e83353f8c42013ee30bf33c6f1283b93861c1bb4699323fa58134bfd2fa01be7507ef3c6f1283b9f42ebebbbf7430bf1e8335bfb973183e3023ed3c6f128339a6de0fbc02d42c3f9e81343fa2215ebec437e93c6f128339e07d0dbc39962dbf1683353fc745463e3023ed3c6f1283b9a6de0fbcc48d2e3f9c8134bf956047bec437e93c6f1283b9e07d0dbce9de2bbf188335bf9de65c3edaf1e43c6f128339fea93dbc7e8d263fa281343f476990be1829e13c6f12833972873abc71e427bf1983353f17b0843edaf1e43c6f1283b9fea93dbcded3283fa08134bf4f6d85be1829e13c6f1283b972873abc49a125bf198335bf759c8f3e108cda3c6f128339bba169bc64ac1e3f9d81343fa95db0be4eefd63c6f12833923c565bcc89420bf1083353f37f6a43e108cda3c6f1283b9bba169bcc579213f988134bf79e1a5be4eefd63c6f1283b923c565bc5dcb1dbf158335bf8c63af3e790bce3c6f128339bbac89bc1544153f9b81343f3d9fcebe9da3ca3c6f1283392d6687bc24b917bf1d83353f86a5c33e790bce3c6f1283b9bbac89bc8591183fa78134bf84bcc4be9da3ca3c6f1283b92d6687bc647014bf128335bf427acd3ee48ebf3c6f1283392d359dbcb06b0a3fac81343f5ee3eabe5464bc3c6f128339f79b9abc7a670dbf2183353f8d72e03ee48ebf3c6f1283b92d359dbc22310e3fa88134bfa0b2e1be5464bc3c6f1283b9f79b9abc65a709bf268335bf3a96e93e093aaf3c6f128339083aafbc567cfc3e9f81343f3b7202bf9554ac3c6f1283399454acbc3eb901bf1783353f3e16fb3e093aaf3c6f1283b9083aafbc3b72023f9f8134bf567cfcbe9554ac3c6f1283b99454acbc3d16fbbe178335bf3eb9013f2e359d3c6f128339e38ebfbca0b2e13ea981343f23310ebff89b9a3c6f1283395364bcbc3a96e9be2683353f64a7093f2e359d3c6f1283b9e38ebfbc5ee3ea3eac8134bfb06b0abff89b9a3c6f1283b95364bcbc8d72e0be218335bf7a670d3fbcac893c6f128339780bcebc80bcc43ea581343f859118bf2e66873c6f1283399ca3cabc3f7acdbe1283353f6470143fbcac893c6f1283b9780bcebc3b9fce3e9b8134bf144415bf2e66873c6f1283b99ca3cabc86a5c3be1d8335bf27b9173fbca1693c6f1283390f8cdabc78e1a53e9a81343fc67921bf24c5653c6f1283394defd6bc8963afbe1483353f5ecb1d3fbca1693c6f1283b90f8cdabca75db03e9c8134bf64ac1ebf24c5653c6f1283b94defd6bc36f6a4be108335bfc794203fffa93d3c6f128339d9f1e4bc506d853ea081343fddd328bf73873a3c6f1283391729e1bc769c8fbe1983353f49a1253fffa93d3c6f1283b9d9f1e4bc4869903ea18134bf7d8d26bf73873a3c6f1283b91729e1bc18b084be198335bf70e4273fa8de0f3c6f1283392f23edbc9760473e9c81343fc58d2ebfe27d0d3c6f128339c337e9bc9ee65cbe1883353fe6de2b3fa8de0f3c6f1283b92f23edbca2215e3e9e8134bf01d42cbfe27d0d3c6f1283b9c337e9bcc94546be158335bf39962d3f3c61c13b6f128339e20bf3bce6fa013ea581343f459932bff82ebe3b6f1283397407efbcc27318be1d83353fbe74303f3c61c13b6f1283b9e20bf3bc344d193ea58134bf627031bff82ebe3b6f1283b97407efbca04201be1e8335bffb9b313fca50423b6f1283395e9df6bc34536d3d9b81343f87ec34bf901a3f3b6f128339d889f2bc1e12a5bd1483353f9b57333fca50423b6f1283b95e9df6bc6cfda53d9c8134bf5c5734bf901a3f3b6f1283b9d889f2bc64026cbd138335bff2eb333fea4918316f128339d8cef7bc073a3ebca781343fa68135bf84c515316f12833944b6f3bc5d2b3dbc1e83353f3e80343fea4918316f1283b9d8cef7bc073a3e3ca88134bfa68135bf84c515316f1283b944b6f3bc5d2b3d3c1e8335bf3e80343fb75042bb6f1283395e9df6bc46fda5bd9c81343f5d5734bf7d1a3fbb6f128339d889f2bc40026c3d1283353ff3eb333fb75042bb6f1283b95e9df6bc0d536dbd9b8134bf88ec34bf7d1a3fbb6f1283b9d889f2bcf811a53d168335bf9c57333f3261c1bb6f128339e30bf3bc2b4d19bea581343f627031bfee2ebebb6f1283397507efbc8c42013e1e83353ffb9b313f3261c1bb6f1283b9e30bf3bcd3fa01bea68134bf459932bfee2ebebb6f1283b97507efbcb973183e1d8335bfbe74303fa3de0fbc6f1283393023edbca2215ebe9e81343f02d42cbfdd7d0dbc6f128339c437e9bcc745463e1683353f39962d3fa3de0fbc6f1283b93023edbc956047be9c8134bfc48d2ebfdd7d0dbc6f1283b9c437e9bc9de65c3e188335bfe9de2b3ffba93dbc6f128339daf1e4bc476990bea281343f7e8d26bf6f873abc6f1283391829e1bc17b0843e1983353f71e4273ffba93dbc6f1283b9daf1e4bc4f6d85bea08134bfded328bf6f873abc6f1283b91829e1bc759c8f3e198335bf49a1253fb8a169bc6f128339108cdabca75db0be9c81343f64ac1ebf20c565bc6f1283394eefd6bc36f6a43e1083353fc794203fb8a169bc6f1283b9108cdabc78e1a5be9a8134bfc67921bf20c565bc6f1283b94eefd6bc8b63af3e148335bf5ecb1d3fbaac89bc6f128339790bcebc3c9fcebe9b81343f154415bf2c6687bc6f1283399da3cabc85a5c33e1d83353f26b9173fbaac89bc6f1283b9790bcebc80bcc4bea68134bf859118bf2c6687bc6f1283b99da3cabc3f7acd3e128335bf6470143f2c359dbc6f128339e48ebfbc5be3eabeac81343fb36b0abff69b9abc6f1283395464bcbc8972e03e2283353f79670d3f2c359dbc6f1283b9e48ebfbc9db2e1bea98134bf23310ebff69b9abc6f1283b95464bcbc3696e93e258335bf67a7093f083aafbc6f128339093aafbc3b7202bfa181343f517cfcbe9454acbc6f1283399554acbc3e16fb3e1683353f40b9013f083aafbc6f1283b9093aafbc567cfcbe9c8134bf3e7202bf9454acbc6f1283b99554acbc3eb9013f1a8335bf3816fb3ee28ebfbc6f1283392e359dbc25310ebfa881343f9eb2e1be5264bcbc6f128339f89b9abc66a7093f2783353f3396e93ee28ebfbc6f1283b92e359dbcb36b0abfaf8134bf59e3eabe5264bcbc6f1283b9f89b9abc7b670d3f1f8335bf8a72e03e770bcebc6f128339bcac89bc859118bfa781343f84bcc4be9ba3cabc6f1283392e6687bc6470143f1283353f427acd3e770bcebc6f1283b9bcac89bc154415bf9b8134bf3d9fcebe9ba3cabc6f1283b92e6687bc24b9173f1d8335bf86a5c33e0e8cdabc6f128339bda169bcc57921bf9881343f79e1a5be4cefd6bc6f12833925c565bc5dcb1d3f1583353f8b63af3e0e8cdabc6f1283b9bda169bc64ac1ebf9d8134bfa95db0be4cefd6bc6f1283b925c565bcc794203f108335bf37f6a43ed8f1e4bc6f12833900aa3dbcded328bfa181343f516d85be1629e1bc6f12833974873abc4aa1253f1a83353f779c8f3ed8f1e4bc6f1283b900aa3dbc7d8d26bfa18134bf486990be1629e1bc6f1283b974873abc70e4273f198335bf18b0843e2e23edbc6f128339a9de0fbcc58d2ebf9c81343f976047bec237e9bc6f128339e37d0dbce7de2b3f1983353f9fe65c3e2e23edbc6f1283b9a9de0fbc01d42cbf9e8134bfa2215ebec237e9bc6f1283b9e37d0dbc38962d3f148335bfc745463ee10bf3bc6f1283393e61c1bb459932bfa681343fe7fa01be7307efbc6f128339fa2ebebbbe74303f1d83353fc373183ee10bf3bc6f1283b93e61c1bb627031bfa58134bf354d19be7307efbc6f1283b9fa2ebebbfa9b313f1e8335bfa042013e5d9df6bc6f128339cf5042bb88ec34bf9b81343f35536dbdd789f2bc6f128339951a3fbb9b57333f1583353f1f12a53d5d9df6bc6f1283b9cf5042bb5c5734bf9c8134bf6dfda5bdd789f2bc6f1283b9951a3fbbf3eb333f148335bf67026c3dd7cef7bc6f128339228071b1a68135bfa781343f073a3e3c43b6f3bc6f12833940826db13e80343f1f83353f5e2b3d3cd7cef7bc6f1283b9228071b1a68135bfa78134bf073a3ebc43b6f3bc6f1283b940826db13e80343f1f8335bf5e2b3dbc5d9df6bc6f128339b150423b5c5734bf9c81343f46fda53dd789f2bc6f128339771a3f3bf3eb333f1283353f40026cbd5d9df6bc6f1283b9b150423b88ec34bf9b8134bf0d536d3dd789f2bc6f1283b9771a3f3b9b57333f158335bff611a5bde20bf3bc6f1283392f61c13b637031bfa481343f2a4d193e7407efbc6f128339eb2ebe3bfb9b313f1e83353f8c4201bee20bf3bc6f1283b92f61c13b469932bfa68134bfd3fa013e7407efbc6f1283b9eb2ebe3bbf74303f1e8335bfb97318be2f23edbc6f128339a2de0f3c01d42cbf9e81343fa2215e3ec337e9bc6f128339dc7d0d3c39962d3f1583353fc74546be2f23edbc6f1283b9a2de0f3cc58d2ebf9b8134bf9560473ec337e9bc6f1283b9dc7d0d3ce7de2b3f198335bf9ee65cbed9f1e4bc6f128339f9a93d3c7d8d26bfa081343f4869903e1729e1bc6f1283396d873a3c70e4273f1983353f18b084bed9f1e4bc6f1283b9f9a93d3cded328bfa18134bf516d853e1729e1bc6f1283b96d873a3c4aa1253f1a8335bf779c8fbe0f8cdabc6f128339b6a1693c64ac1ebf9c81343fa75db03e4defd6bc6f1283391ec5653cc794203f1083353f36f6a4be0f8cdabc6f1283b9b6a1693cc57921bf998134bf77e1a53e4defd6bc6f1283b91ec5653c5ecb1d3f148335bf8b63afbe780bcebc6f128339b9ac893c154415bf9b81343f3c9fce3e9ca3cabc6f1283392b66873c27b9173f1e83353f86a5c3be780bcebc6f1283b9b9ac893c859118bfa68134bf80bcc43e9ca3cabc6f1283b92b66873c6470143f128335bf3f7acdbee38ebfbc6f1283392b359d3cb36b0abfac81343f5be3ea3e5364bcbc6f128339f59b9a3c79670d3f2283353f8972e0bee38ebfbc6f1283b92b359d3c23310ebfa98134bf9db2e13e5364bcbc6f1283b9f59b9a3c67a7093f258335bf3696e9be083aafbc6f128339073aaf3c507cfcbea081343f3a72023f9454acbc6f1283399354ac3c40b9013f1683353f3e16fbbe083aafbc6f1283b9073aaf3c3e7202bf9c8134bf567cfc3e9454acbc6f1283b99354ac3c3816fb3e1a8335bf3eb901bf2d359dbc6f128339e18ebf3c9eb2e1bea881343f25310e3ff79b9abc6f1283395164bc3c3296e93e2683353f65a709bf2d359dbc6f1283b9e18ebf3c57e3eabeae8134bfb26b0a3ff79b9abc6f1283b95164bc3c8a72e03e1f8335bf7b670dbfbbac89bc6f128339760bce3c84bcc4bea781343f8591183f2d6687bc6f1283399aa3ca3c427acd3e1283353f647014bfbbac89bc6f1283b9760bce3c3d9fcebe9b8134bf1544153f2d6687bc6f1283b99aa3ca3c86a5c33e1d8335bf24b917bfbba169bc6f1283390d8cda3c79e1a5be9881343fc579213f23c565bc6f1283394befd63c8b63af3e1583353f5dcb1dbfbba169bc6f1283b90d8cda3ca95db0be9d8134bf64ac1e3f23c565bc6f1283b94befd63c37f6a43e108335bfc79420bffea93dbc6f128339d7f1e43c506d85bea081343fddd3283f72873abc6f1283391529e13c769c8f3e1983353f49a125bffea93dbc6f1283b9d7f1e43c486990bea18134bf7d8d263f72873abc6f1283b91529e13c18b0843e198335bf70e427bfa7de0fbc6f1283392d23ed3c976047be9c81343fc58d2e3fe17d0dbc6f128339c137e93c9ee65c3e1883353fe6de2bbfa7de0fbc6f1283b92d23ed3ca2215ebe9e8134bf01d42c3fe17d0dbc6f1283b9c137e93cc945463e158335bf39962dbf3a61c1bb6f128339e00bf33ce7fa01bea681343f4599323ff62ebebb6f1283397207ef3cc373183e1d83353fbe7430bf3a61c1bb6f1283b9e00bf33c354d19bea58134bf6270313ff62ebebb6f1283b97207ef3ca042013e1e8335bffa9b31bfc85042bb6f1283395c9df63c35536dbd9b81343f87ec343f8e1a3fbb6f128339d689f23c2012a53d1583353f9b5733bfc85042bb6f1283b95c9df63c6efda5bd9c8134bf5c57343f8e1a3fbb6f1283b9d689f23c67026c3d148335bff2eb33bf56c011b16f128339d6cef73c083a3e3ca681343fa681353f9a570fb16f12833942b6f33c5e2b3d3c1e83353f3e8034bf56c011b16f1283b9d6cef73c083a3ebca68134bfa681353f9a570fb16f1283b942b6f33c5e2b3dbc1e8335bf3e8034bfb650423b6f1283395c9df63c48fda53d9d81343f5d57343f7c1a3f3b6f128339d689f23c42026cbd1483353ff3eb33bfb650423b6f1283b95c9df63c0f536d3d9b8134bf88ec343f7c1a3f3b6f1283b9d689f23cf811a5bd158335bf9b5733bf3161c13b6f128339e10bf33c2a4d193ea481343f6370313fed2ebe3b6f1283397307ef3c8c4201be1e83353ffb9b31bf3161c13b6f1283b9e10bf33cd3fa013ea68134bf4699323fed2ebe3b6f1283b97307ef3cb97318be1d8335bfbf7430bfa3de0f3c6f1283392e23ed3ca2215e3e9e81343f01d42c3fdd7d0d3c6f128339c237e93cc74546be1583353f39962dbfa3de0f3c6f1283b92e23ed3c9560473e9b8134bfc58d2e3fdd7d0d3c6f1283b9c237e93c9ee65cbe198335bfe7de2bbffaa93d3c6f128339d8f1e43c4869903ea081343f7d8d263f6e873a3c6f1283391629e13c18b084be1983353f70e427bffaa93d3c6f1283b9d8f1e43c506d853ea08134bfddd3283f6e873a3c6f1283b91629e13c769c8fbe198335bf49a125bfb7a1693c6f1283390e8cda3ca95db03e9d81343f64ac1e3f1fc5653c6f1283394cefd63c37f6a4be1083353fc89420bfb7a1693c6f1283b90e8cda3c79e1a53e988134bfc579213f1fc5653c6f1283b94cefd63c8c63afbe158335bf5dcb1dbfb9ac893c6f128339770bce3c3d9fce3e9b81343f1544153f2b66873c6f1283399ba3ca3c86a5c3be1d83353f24b917bfb9ac893c6f1283b9770bce3c84bcc43ea78134bf8591183f2b66873c6f1283b99ba3ca3c427acdbe128335bf647014bf2b359d3c6f128339e28ebf3c54e3ea3eac81343fb56b0a3ff59b9a3c6f1283395264bc3c8872e0be2183353f7c670dbf2b359d3c6f1283b9e28ebf3c9ab2e13ea88134bf24310e3ff59b9a3c6f1283b95264bc3c2f96e9be268335bf69a709bf073aaf3c6f128339083aaf3c3e72023f9f81343f517cfc3e9354ac3c6f1283399454ac3c3916fbbe1983353f40b901bf073aaf3c6f1283b9083aaf3c517cfc3e9f8134bf3e72023f9354ac3c6f1283b99454ac3c40b901bf178335bf3816fbbee18ebf3c6f1283392c359d3c24310e3fa881343f99b2e13e5164bc3c6f128339f69b9a3c68a709bf2583353f2f96e9bee18ebf3c6f1283b92c359d3cb56b0a3fac8134bf54e3ea3e5164bc3c6f1283b9f69b9a3c7b670dbf218335bf8772e0be760bce3c6f128339baac893c8591183fa781343f84bcc43e9aa3ca3c6f1283392c66873c647014bf1283353f427acdbe760bce3c6f1283b9baac893c1544153f9b8134bf3d9fce3e9aa3ca3c6f1283b92c66873c24b917bf1d8335bf86a5c3be0d8cda3c6f128339b9a1693cc579213f9881343f79e1a53e4befd63c6f12833921c5653c5dcb1dbf1583353f8b63afbe0d8cda3c6f1283b9b9a1693c64ac1e3f9d8134bfa95db03e4befd63c6f1283b921c5653cc79420bf108335bf37f6a4bed7f1e43c6f128339fca93d3cded3283fa181343f516d853e1529e13c6f12833970873a3c4aa125bf1a83353f779c8fbed7f1e43c6f1283b9fca93d3c7d8d263fa18134bf4869903e1529e13c6f1283b970873a3c70e427bf198335bf18b084be2d23ed3c6f128339a5de0f3cc58d2e3f9c81343f9760473ec137e93c6f128339df7d0d3ce7de2bbf1983353f9fe65cbe2d23ed3c6f1283b9a5de0f3c01d42c3f9e8134bfa2215e3ec137e93c6f1283b9df7d0d3c38962dbf148335bfc74546bee00bf33c6f1283393661c13b4599323fa681343fe7fa013e7207ef3c6f128339f22ebe3bbe7430bf1d83353fc37318bee00bf33c6f1283b93661c13b6270313fa58134bf354d193e7207ef3c6f1283b9f22ebe3bfa9b31bf1e8335bfa04201be5c9df63c6f128339c050423b87ec343f9b81343f25546d3dd689f23c6f128339861a3f3b9a5733bf1483353f5a12a5bd5c9df63c6f1283b9c050423b5b57343f9c8134bfa9fda53dd689f23c6f1283b9861a3f3bf1eb33bf138335bf57036cbd
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
-    m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshOptimized: 0
 --- !u!1 &1433105875
 GameObject:
   m_ObjectHideFlags: 0
@@ -19142,6 +30128,104 @@ Material:
     m_Floats: []
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &1445655199
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1198712356848052, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1445655200}
+  m_Layer: 0
+  m_Name: Color Swatch (25)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1445655200
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4592608246599776, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1445655199}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -0.8611212, y: 3.36, z: -0.84}
+  m_LocalScale: {x: 0.38721097, y: 0.3872097, z: 0.38721007}
+  m_Children:
+  - {fileID: 1330166009}
+  - {fileID: 1715423707}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 26
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1446189234
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1536610378}
+    m_Modifications:
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Name
+      value: Button Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &1446189235 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_PrefabInternal: {fileID: 1446189234}
 --- !u!1 &1448418659
 GameObject:
   m_ObjectHideFlags: 0
@@ -19242,6 +30326,72 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 2
+--- !u!1001 &1449351596
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 472929502}
+    m_Modifications:
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Name
+      value: Button Surface
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &1449351597 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
+  m_PrefabInternal: {fileID: 1449351596}
 --- !u!1001 &1449626500
 Prefab:
   m_ObjectHideFlags: 0
@@ -19258,6 +30408,11 @@ Prefab:
         type: 2}
       propertyPath: soundEffect._clips.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4000013939052844, guid: c915520bed265f24c95aebc38ee51557, type: 2}
       propertyPath: m_LocalPosition.x
@@ -19344,6 +30499,31 @@ Prefab:
     - target: {fileID: 0}
       propertyPath: m_RootOrder
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1840705451}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: NotifyColorPalleteTouched
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c915520bed265f24c95aebc38ee51557, type: 2}
@@ -19538,6 +30718,157 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DeactivateOnDisable: 1
   Transition: {fileID: 0}
+--- !u!1 &1455894658
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1455894659}
+  m_Layer: 0
+  m_Name: Ribbon Brush Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1455894659
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1455894658}
+  m_LocalRotation: {x: -0, y: -0, z: -0.0000000013969839, w: 1}
+  m_LocalPosition: {x: 2.53, y: 0, z: -2.22}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 767898359}
+  - {fileID: 735067418}
+  - {fileID: 1184242367}
+  m_Father: {fileID: 150231449}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+--- !u!1 &1455914324
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1366733452938832, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1455914325}
+  m_Layer: 0
+  m_Name: Color Swatch (14)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1455914325
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4606144556035096, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1455914324}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -0.8611212, y: 1.86, z: -0.71}
+  m_LocalScale: {x: 0.3872106, y: 0.38720962, z: 0.38720992}
+  m_Children:
+  - {fileID: 1648580833}
+  - {fileID: 1567509735}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1458460964
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1458460965}
+  - component: {fileID: 1458460968}
+  - component: {fileID: 1458460967}
+  - component: {fileID: 1458460966}
+  m_Layer: 0
+  m_Name: RectToroid (Pinch State)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1458460965
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1458460964}
+  m_LocalRotation: {x: 0.000000014901159, y: -0, z: -0.0000000027939675, w: 1}
+  m_LocalPosition: {x: -0.0000000012060912, y: -0.0000000010747403, z: 0.000000011669111}
+  m_LocalScale: {x: 1.0000002, y: 1.0000002, z: 1.0000006}
+  m_Children: []
+  m_Father: {fileID: 1655177877}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1458460966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1458460964}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47976be3b9532f74496fd7dcdcd3d4b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _radius: 1
+  _radialThickness: 0.2
+  _verticalThickness: 0.02
+  _alwaysUpdate: 1
+--- !u!33 &1458460967
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1458460964}
+  m_Mesh: {fileID: 1602476091}
+--- !u!23 &1458460968
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1458460964}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &1463119601
 GameObject:
   m_ObjectHideFlags: 0
@@ -19583,6 +30914,80 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   DeactivateOnDisable: 1
   Transition: {fileID: 0}
+--- !u!1 &1465239053
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1465239054}
+  - component: {fileID: 1465239056}
+  - component: {fileID: 1465239055}
+  m_Layer: 0
+  m_Name: (Put hands down)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1465239054
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1465239053}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1465239055
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1465239053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 227293553}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &1465239056
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1465239053}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: SkipMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: WaitForColor
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1 &1466210547
 GameObject:
   m_ObjectHideFlags: 0
@@ -19679,6 +31084,82 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+--- !u!1 &1472483590
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1429717773280006, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1472483591}
+  - component: {fileID: 1472483593}
+  - component: {fileID: 1472483592}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1472483591
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4989826977246000, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1472483590}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.08476253, y: 0.32325196, z: 0.35676438}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1101815129}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1472483592
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23748280086843902, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1472483590}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1472483593
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33286983005597770, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1472483590}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &1472859814
 GameObject:
   m_ObjectHideFlags: 0
@@ -19751,6 +31232,38 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1472859814}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1478040349
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1478040350}
+  m_Layer: 0
+  m_Name: Coming Soon Button (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1478040350
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1478040349}
+  m_LocalRotation: {x: -0.00000008940696, y: -0.000000010244547, z: -0.0000000025611369,
+    w: 1}
+  m_LocalPosition: {x: -2.45, y: 0, z: -2.22}
+  m_LocalScale: {x: 1.0000001, y: 1.0000001, z: 1}
+  m_Children:
+  - {fileID: 2036328861}
+  - {fileID: 1492936919}
+  - {fileID: 1175529919}
+  m_Father: {fileID: 150231449}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
 --- !u!21 &1487414641
 Material:
   serializedVersion: 6
@@ -19776,6 +31289,108 @@ Material:
     m_Floats: []
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1001 &1492936918
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1478040350}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Surface
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &1492936919 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 1492936918}
+--- !u!1 &1509140292
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1027893971613406, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1509140293}
+  m_Layer: 0
+  m_Name: Mixing Basin
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1509140293
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4563070347570590, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1509140292}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.345, y: -0.68, z: 1.26}
+  m_LocalScale: {x: 0.00999999, y: 0.00999999, z: 0.00999999}
+  m_Children:
+  - {fileID: 1186674471}
+  - {fileID: 1738942289}
+  m_Father: {fileID: 2010003633}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1509526757
 GameObject:
   m_ObjectHideFlags: 0
@@ -19848,6 +31463,132 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1509526757}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1510378714
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000010656060444, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1510378715}
+  - component: {fileID: 1510378718}
+  - component: {fileID: 1510378717}
+  - component: {fileID: 1510378716}
+  m_Layer: 0
+  m_Name: Index Tip Paint L
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1510378715
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000011347618324, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1510378714}
+  m_LocalRotation: {x: -0.99011445, y: -0.12504648, z: 0.007486235, w: -0.063093245}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0014}
+  m_LocalScale: {x: -0.014959458, y: -0.014959458, z: -0.014959458}
+  m_Children: []
+  m_Father: {fileID: 445224930}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 7.235, y: -180.05399, z: 165.906}
+--- !u!114 &1510378716
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1510378714}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00f8d6ed2b677314896e1968924c49c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _bindings:
+  - 'MeshRenderer : material._Color.r'
+  - 'MeshRenderer : material._Color.g'
+  - 'MeshRenderer : material._Color.b'
+  - 'MeshRenderer : material._Color.a'
+  _expandedTypes: []
+--- !u!23 &1510378717
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23000011798768822, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1510378714}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: b56dc6412c0c068418e3d57118a19467, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1510378718
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33000012481087388, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1510378714}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1513574474
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1855578846077704, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1513574475}
+  m_Layer: 0
+  m_Name: Color Swatch (20)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1513574475
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4578565163035068, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1513574474}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: -0.44844532, y: 2.6, z: -0.78}
+  m_LocalScale: {x: 0.38721097, y: 0.3872097, z: 0.38721007}
+  m_Children:
+  - {fileID: 1334572880}
+  - {fileID: 736830610}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 21
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1517780350
 Prefab:
   m_ObjectHideFlags: 0
@@ -19946,6 +31687,67 @@ Transform:
   m_Father: {fileID: 256381097}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1529262420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1529262421}
+  m_Layer: 0
+  m_Name: Brush Controls Emergeable Parent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1529262421
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1529262420}
+  m_LocalRotation: {x: 0.017484082, y: -0.6877809, z: -0.72570133, w: -0.0030548717}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 0.3750002, y: 0.3750003, z: 0.37500054}
+  m_Children:
+  - {fileID: 368390649}
+  - {fileID: 2049983040}
+  - {fileID: 616489409}
+  m_Father: {fileID: 1832814775}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: -86.712006, y: -21.665, z: -160}
+--- !u!1 &1529389050
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1117376421218776, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1529389051}
+  m_Layer: 0
+  m_Name: Box Collider (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1529389051
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4894885121423522, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1529389050}
+  m_LocalRotation: {x: -0.00000001862645, y: 0.30259603, z: 0.000000013038514, w: 0.9531189}
+  m_LocalPosition: {x: -0.0600001, y: 0.029997999, z: -0.1600015}
+  m_LocalScale: {x: 5.1319532, y: 0.2857803, z: 5.1319537}
+  m_Children: []
+  m_Father: {fileID: 1738942289}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 35.444, z: 0}
 --- !u!1001 &1536454668
 Prefab:
   m_ObjectHideFlags: 0
@@ -20017,6 +31819,97 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: ec0802f021331cd4d96296dee2161743,
     type: 3}
   m_PrefabInternal: {fileID: 1536454668}
+--- !u!1 &1536610377
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1536610378}
+  m_Layer: 0
+  m_Name: Redo Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1536610378
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1536610377}
+  m_LocalRotation: {x: 0.00000061467284, y: 1, z: 0.000000051222706, w: 0.000000104308185}
+  m_LocalPosition: {x: 1.9933313, y: -0.009996284, z: -0.9033345}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1446189235}
+  - {fileID: 1276157321}
+  - {fileID: 765684906}
+  m_Father: {fileID: 616489409}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1541230323
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1541230324}
+  - component: {fileID: 1541230326}
+  - component: {fileID: 1541230325}
+  m_Layer: 0
+  m_Name: Now, don't we need more colors?
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1541230324
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1541230323}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 28
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1541230325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1541230323}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76f3179ee3c21564a81795625cc0cabb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 789892009}
+  transitionState: {fileID: 0}
+  controller: {fileID: 1649983743}
+  markerName: TryWidget
+  condition: 1
+--- !u!114 &1541230326
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1541230323}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 058111a9d90a4f043bc9b61354670d93, type: 2}
+  _wrapMode: 2
 --- !u!43 &1543963394
 Mesh:
   m_ObjectHideFlags: 3
@@ -20103,7 +31996,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 528
-    _typelessdata: fe1b21bc5c1db43a000000000000803f0000803f0000803f0000803f0000903d00003c3f000000000000000040c32e395c1db43a000000000000803f0000803f0000803f0000803f0000903d00002d3f000000000000000040c32e39ec58b8bb000000000000803f0000803f0000803f0000803f0000f03c00002d3f0000000000000000fe1b21bcec58b8bb000000000000803f0000803f0000803f0000803f0000f03c00003c3f000000000000000010745a3a84f9723b000000000000803f0000803f0000803f0000803f0000b53e00009d3e00000000000000004360653b84f9723b000000000000803f0000803f0000803f0000803f0000bd3e00009d3e00000000000000004360653bec58b8bb000000000000803f0000803f0000803f0000803f0000bd3e0000b93e000000000000000010745a3aec58b8bb000000000000803f0000803f0000803f0000803f0000b53e0000b93e00000000000000004360653b5c1db43a000000000000803f0000803f0000803f0000803f0000803e0000ea3e000000000000000032082c3c5c1db43a000000000000803f0000803f0000803f0000803f0000953e0000ea3e000000000000000032082c3cec58b8bb000000000000803f0000803f0000803f0000803f0000953e0000ff3e00000000000000004360653bec58b8bb000000000000803f0000803f0000803f0000803f0000803e0000ff3e0000000000000000
+    _typelessdata: fe1b21bc5c1db43a000000000000803f0000803f0000803f0000803f0000783e0080343f000000000000000040c32e395c1db43a000000000000803f0000803f0000803f0000803f0000783e0080253f000000000000000040c32e39ec58b8bb000000000000803f0000803f0000803f0000803f00004e3e0080253f0000000000000000fe1b21bcec58b8bb000000000000803f0000803f0000803f0000803f00004e3e0080343f000000000000000010745a3a84f9723b000000000000803f0000803f0000803f0000803f0000f03e0000b23e00000000000000004360653b84f9723b000000000000803f0000803f0000803f0000803f0000f83e0000b23e00000000000000004360653bec58b8bb000000000000803f0000803f0000803f0000803f0000f83e0000ce3e000000000000000010745a3aec58b8bb000000000000803f0000803f0000803f0000803f0000f03e0000ce3e00000000000000004360653b5c1db43a000000000000803f0000803f0000803f0000803f0000703f0000563e000000000000000032082c3c5c1db43a000000000000803f0000803f0000803f0000803f00807a3f0000563e000000000000000032082c3cec58b8bb000000000000803f0000803f0000803f0000803f00807a3f0000803e00000000000000004360653bec58b8bb000000000000803f0000803f0000803f0000803f0000703f0000803e0000000000000000
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -20163,6 +32056,35 @@ Mesh:
   m_BakedConvexCollisionMesh: 
   m_BakedTriangleCollisionMesh: 
   m_MeshOptimized: 0
+--- !u!1 &1544470582
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1544470583}
+  m_Layer: 0
+  m_Name: PinkyMiddleJoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1544470583
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1544470582}
+  m_LocalRotation: {x: -0.000000059604645, y: -0, z: 0.000000004656613, w: 1}
+  m_LocalPosition: {x: -0.0000000018626451, y: 0.000000055879354, z: 0.03273998}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1230328468}
+  m_Father: {fileID: 1104466513}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1551864430
 GameObject:
   m_ObjectHideFlags: 0
@@ -20355,6 +32277,144 @@ Transform:
   m_Father: {fileID: 27373162}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1555422910
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1555422911}
+  - component: {fileID: 1555422914}
+  - component: {fileID: 1555422913}
+  - component: {fileID: 1555422912}
+  m_Layer: 0
+  m_Name: BotHead
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1555422911
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1555422910}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.627, z: 0}
+  m_LocalScale: {x: 0.14530975, y: 0.14530976, z: 0.14530976}
+  m_Children:
+  - {fileID: 1860839465}
+  - {fileID: 991967092}
+  m_Father: {fileID: 1311336093}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1555422912
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1555422910}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6748749169650b947aaa5361736a9747, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  discontinuity: {fileID: 1649983741}
+  src: {fileID: 94561691}
+  performSmoothing: 1
+  returnStrengthMult: 0.01
+  positionReturnStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 0.049999997
+      value: 1
+      inSlope: 58.481136
+      outSlope: 58.481136
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+  rotationReturnStrength:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 5
+      value: 1
+      inSlope: 0.58206725
+      outSlope: 0.58206725
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 0
+--- !u!23 &1555422913
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1555422910}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1555422914
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1555422910}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1558249328
 GameObject:
   m_ObjectHideFlags: 0
@@ -20643,51 +32703,46 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 1561530193}
---- !u!1 &1564808030
+--- !u!1 &1567509734
 GameObject:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 1064091000539370, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 1564808031}
-  - component: {fileID: 1564808033}
-  - component: {fileID: 1564808032}
-  - component: {fileID: 1564808034}
+  - component: {fileID: 1567509735}
+  - component: {fileID: 1567509737}
+  - component: {fileID: 1567509736}
   m_Layer: 0
-  m_Name: RectToroid (Pinch Target)
+  m_Name: Color Layer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1564808031
+--- !u!4 &1567509735
 Transform:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 4700136366669346, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1564808030}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_GameObject: {fileID: 1567509734}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.0550363, y: 0.733933, z: -0.114444986}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
   m_Children: []
-  m_Father: {fileID: 2085845413}
-  m_RootOrder: 0
+  m_Father: {fileID: 1455914325}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &1564808032
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1564808030}
-  m_Mesh: {fileID: 1431168179}
---- !u!23 &1564808033
+--- !u!23 &1567509736
 MeshRenderer:
   m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
+  m_PrefabParentObject: {fileID: 23890838212300406, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1564808030}
-  m_Enabled: 1
+  m_GameObject: {fileID: 1567509734}
+  m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
   m_DynamicOccludee: 1
@@ -20696,7 +32751,7 @@ MeshRenderer:
   m_ReflectionProbeUsage: 1
   m_RenderingLayerMask: 4294967295
   m_Materials:
-  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -20716,21 +32771,118 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!114 &1564808034
-MonoBehaviour:
+--- !u!33 &1567509737
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33334094918303254, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1567509734}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1567539283
+GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1564808030}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 47976be3b9532f74496fd7dcdcd3d4b1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _radius: 0.03
-  _radialThickness: 0.00025
-  _verticalThickness: 0.00025
-  _alwaysUpdate: 0
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1567539284}
+  m_Layer: 0
+  m_Name: '--------'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1567539284
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1567539283}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1571408492
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1653964470697572, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1571408493}
+  - component: {fileID: 1571408495}
+  - component: {fileID: 1571408494}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1571408493
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4420737392191176, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1571408492}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.14494722, y: 0.44819272, z: 0.30449834}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 175335083}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1571408494
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23137392015640926, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1571408492}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1571408495
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33482496179525008, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1571408492}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!1 &1580682300
 GameObject:
   m_ObjectHideFlags: 0
@@ -20761,6 +32913,110 @@ Transform:
   m_Father: {fileID: 840054352}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1581307252
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1581307253}
+  m_Layer: 0
+  m_Name: '--------'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1581307253
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1581307252}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1591171697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1336786866039824, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1591171698}
+  - component: {fileID: 1591171700}
+  - component: {fileID: 1591171699}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1591171698
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4164546456475396, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1591171697}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: -0.06820166, y: 0.6507879, z: -0.13597582}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 480798553}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1591171699
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23481538504379552, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1591171697}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1591171700
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33333215424921106, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1591171697}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
 --- !u!21 &1592238503
 Material:
   serializedVersion: 6
@@ -20786,6 +33042,83 @@ Material:
     m_Floats: []
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &1592325209
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1365528920899200, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1592325210}
+  - component: {fileID: 1592325212}
+  - component: {fileID: 1592325211}
+  m_Layer: 0
+  m_Name: Palette Circle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1592325210
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4097900540873120, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1592325209}
+  m_LocalRotation: {x: -9.471823e-15, y: -0.000000021073424, z: 0.000000021073388,
+    w: 1}
+  m_LocalPosition: {x: 0, y: -0, z: 0}
+  m_LocalScale: {x: 3.4000115, y: 1, z: 3.400007}
+  m_Children: []
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1592325211
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23559937822520320, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1592325209}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1592325212
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33156121402020476, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1592325209}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &1593538457
 GameObject:
   m_ObjectHideFlags: 0
@@ -20887,6 +33220,152 @@ Transform:
   m_Father: {fileID: 123298549}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!43 &1602476091
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Ribbon Circle Mesh
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 1536
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 256
+    localAABB:
+      m_Center: {x: 0.00000011920929, y: 0, z: -0.000000059604645}
+      m_Extent: {x: 1.1999999, y: 0.02, z: 1.1999998}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
+  m_Skin: []
+  m_VertexData:
+    serializedVersion: 2
+    m_VertexCount: 256
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 6144
+    _typelessdata: 9a99993f0ad7a33c000000008ef4e43d11657e3f1bf4efbacdcc4c3f0ad7a33c00000000bde6aebd82107f3ff750b7ba9a99993f0ad7a3bc000000008ff4e43d11657ebfebf7ef3acdcc4c3f0ad7a3bc00000000c0e6aebd83107fbf9d4cb73a41dc983f0ad7a33c0ee3f0bd3f7ce33d11657e3fce6151bc57d04b3f0ad7a33c5e97a0bd0457aebd83107f3f50b0e43b41dc983f0ad7a3bc0ee3f0bd6838e43d11657ebfe9ae15bc57d04b3f0ad7a3bc5e97a0bd48c7adbd83107fbf0bf31f3c0ca6963f0ad7a33c1cba6fbe12d3df3d0f657e3f9160c1bc65dd483f0ad7a33c68d11fbe7619acbd82107f3fff7f7a3c0ca6963f0ad7a3bc1cba6fbe9649e13d11657ebf76f5a3bc65dd483f0ad7a3bc68d11fbe5ffbaabd83107fbf09b9933c6cfc923f0ad7a33cd459b2be1e02da3d11657e3f9a190cbd3bfb433f0ad7a33c1bcd6dbe9a33a8bd81107f3f271fc03c6cfc923f0ad7a3bcd459b2be592fdc3d11657ebf727ffbbc3bfb433f0ad7a3bc1bcd6dbeed89a6bd82107fbf3d0cd63c6ce88d3f0ad7a33ce61eebbea517d23d11657e3f9d2936bde5353d3f0ad7a33c44bf9cbe11afa2bd83107f3f4c92003d6ce88d3f0ad7a3bce61eebbe41f6d43d11657ebf8a4e28bde5353d3f0ad7a3bc44bf9cbee37da0bd83107fbfef270b3d8e76873f0ad7a33c25d010bf3227c83d11657e3f84785ebd129e343f0ad7a33c8715c1be6f999bbd82107f3f16d81f3d8e76873f0ad7a3bc25d010bf1db0cb3d11657ebf9b3e51bd129e343f0ad7a3bc8715c1be2be698bd83107fbf9df2293d6e6d7f3f0ad7a33cd1ab2abf5249bc3d11657e3f755182bdf4482a3f0ad7a33cc28fe3be350493bd82107f3fbe933d3d6e6d7f3f0ad7a3bcd1ab2abfce73c03d11657ebfad2a78bdf4482a3f0ad7a3bcc28fe3be80d58fbd83107fbf581a473d04786d3f0ad7a33cb6e242bf3a9bae3d11657e3f5e2594bd02501e3f0ad7a33c7aec01bf800489bd83107f3f107c593d04786d3f0ad7a3bcb6e242bf055db33d11657ebf77598ebd02501e3f0ad7a3bc7aec01bf356285bd83107fbf2e57623d2439593f0ad7a33c223959bfa73e9f3d11657e3f0b8ca4bdc2d0103f0ad7a33cc2d010bffc657bbd82107f3f244c733d2439593f0ad7a3bc223959bf088ca43d11657ebfa53e9fbdc2d0103f0ad7a3bcc2d010bf224c73bd83107fbffa657b3db8e2423f0ad7a33c02786dbf7b598e3d11657e3f085db3bd7aec013f0ad7a33c02501ebf285762bd83107f3f3462853db8e2423f0ad7a3bc02786dbf6025943d11657ebf3b9baebd7aec013f0ad7a3bc02501ebf057c59bd82107fbf7d04893dd2ab2a3f0ad7a33c6d6d7fbfa92a783d11657e3fd073c0bdc38fe33e0ad7a33cf3482abf551a47bd83107f3f7ed58f3dd2ab2a3f0ad7a3bc6d6d7fbf7651823d11657ebf5349bcbdc38fe33e0ad7a3bcf3482abfc1933dbd83107fbf3104933d26d0103f0ad7a33c8d7687bf973e513d11657e3f1fb0cbbd8815c13e0ad7a33c129e34bfa2f229bd83107f3f2de6983d26d0103f0ad7a3bc8d7687bf80785e3d10657ebf3727c8bd8815c13e0ad7a3bc129e34bf13d81fbd82107fbf71999b3de71eeb3e0ad7a33c6be88dbfa04e283d11657e3f40f6d4bd45bf9c3e0ad7a33ce4353dbfe6270bbd83107f3fe57da03de71eeb3e0ad7a3bc6be88dbfa729363d11657ebfa417d2bd45bf9c3e0ad7a3bce4353dbf489200bd82107fbf12afa23dd759b23e0ad7a33c6cfc92bf617ffb3c11657e3f592fdcbd1ecd6d3e0ad7a33c3afb43bf3f0cd6bc83107f3fed89a63dd759b23e0ad7a3bc6cfc92bfa5190c3d11657ebf1b02dabd1ecd6d3e0ad7a3bc3afb43bf291fc0bc82107fbf9b33a83d21ba6f3e0ad7a33c0ba696bf8af5a33c11657e3f9649e1bd6bd11f3e0ad7a33c64dd48bf09b993bc83107f3f5ffbaa3d21ba6f3e0ad7a3bc0ba696bf7d60c13c0f657ebf14d3dfbd6bd11f3e0ad7a3bc64dd48bf02807abc83107fbf7619ac3d18e3f03d0ad7a33c41dc98bfc0ae153c11657e3f6638e4bd6697a03d0ad7a33c56d04bbf0af31fbc83107f3f47c7ad3d18e3f03d0ad7a3bc41dc98bff561513c11657ebf3e7ce3bd6697a03d0ad7a3bc56d04bbf51b0e4bb83107fbf0357ae3da5c9bc330ad7a33c999999bf1ef4efba11657e3f8ff4e4bd86b77b330ad7a33ccccc4cbf134eb7ba83107f3fc1e6ae3da5c9bc330ad7a3bc999999bf1ef4ef3a11657ebf8ff4e4bd86b77b330ad7a3bccccc4cbf114eb73a83107fbfc0e6ae3d00e3f0bd0ad7a33c41dc98bfa56151bc11657e3f3f7ce3bd5697a0bd0ad7a33c56d04bbf23b0e43b82107f3f0357ae3d00e3f0bd0ad7a3bc41dc98bf98ae15bc11657ebf6638e4bd5697a0bd0ad7a3bc56d04bbfdbf21f3c83107fbf47c7ad3d15ba6fbe0ad7a33c0ca696bf9160c1bc0f657e3f13d3dfbd63d11fbe0ad7a33c65dd48bfd07f7a3c82107f3f7519ac3d15ba6fbe0ad7a3bc0ca696bf76f5a3bc11657ebf9649e1bd63d11fbe0ad7a3bc65dd48bffdb8933c83107fbf5ffbaa3dd159b2be0ad7a33c6cfc92bf9b190cbd11657e3f1d02dabd16cd6dbe0ad7a33c3bfb43bf291fc03c82107f3f9d33a83dd159b2be0ad7a3bc6cfc92bf747ffbbc11657ebf5a2fdcbd16cd6dbe0ad7a3bc3bfb43bf3d0cd63c83107fbfee89a63de21eebbe0ad7a33c6ce88dbf9a2936bd11657e3fa517d2bd42bf9cbe0ad7a33ce5353dbf4a92003d82107f3f10afa23de21eebbe0ad7a3bc6ce88dbf8a4e28bd11657ebf41f6d4bd42bf9cbe0ad7a3bce5353dbfef270b3d82107fbfe47da03d24d010bf0ad7a33c8e7687bf82785ebd11657e3f3427c8bd8515c1be0ad7a33c129e34bf16d81f3d82107f3f6f999b3d24d010bf0ad7a3bc8e7687bf983e51bd11657ebf1fb0cbbd8515c1be0ad7a3bc129e34bf99f2293d82107fbf28e6983dd0ab2abf0ad7a33c6e6d7fbf755182bd11657e3f5249bcbdc08fe3be0ad7a33cf4482abfbe933d3d82107f3f3504933dd0ab2abf0ad7a3bc6e6d7fbfad2a78bd11657ebfce73c0bdc08fe3be0ad7a3bcf4482abf581a473d83107fbf80d58f3db5e242bf0ad7a33c04786dbf5e2594bd11657e3f3a9baebd79ec01bf0ad7a33c02501ebf107c593d83107f3f8004893db5e242bf0ad7a3bc04786dbf77598ebd11657ebf055db3bd79ec01bf0ad7a3bc02501ebf2e57623d83107fbf3562853d213959bf0ad7a33c243959bf0b8ca4bd11657e3fa73e9fbdc1d010bf0ad7a33cc2d010bf244c733d82107f3ffc657b3d213959bf0ad7a3bc243959bfa53e9fbd11657ebf088ca4bdc1d010bf0ad7a3bcc2d010bffa657b3d83107fbf224c733d01786dbf0ad7a33cb8e242bf085db3bd11657e3f7b598ebd01501ebf0ad7a33c7aec01bf3462853d83107f3f2857623d01786dbf0ad7a3bcb8e242bf3b9baebd11657ebf602594bd01501ebf0ad7a3bc7aec01bf7d04893d82107fbf057c593d6c6d7fbf0ad7a33cd2ab2abfce73c0bd11657e3fb42a78bdf2482abf0ad7a33cc38fe3be7dd58f3d84107f3f561a473d6c6d7fbf0ad7a3bcd2ab2abf5249bcbd11657ebf795182bdf2482abf0ad7a3bcc38fe3be2d04933d82107fbfc1933d3d8d7687bf0ad7a33c27d010bf1fb0cbbd11657e3f883e51bd119e34bf0ad7a33c8915c1be29e6983d82107f3fa3f2293d8d7687bf0ad7a3bc27d010bf3527c8bd10657ebf81785ebd119e34bf0ad7a3bc8915c1be71999b3d83107fbf14d81f3d6ae88dbf0ad7a33ce81eebbe43f6d4bd10657e3f974e28bde3353dbf0ad7a33c46bf9cbee67da03d84107f3fed270b3d6ae88dbf0ad7a3bce81eebbea817d2bd10657ebf942936bde3353dbf0ad7a3bc46bf9cbe12afa23d82107fbf5492003d6bfc92bf0ad7a33cd859b2be5a2fdcbd10657e3f627ffbbc3afb43bf0ad7a33c20cd6dbef089a63d84107f3f500cd63c6bfc92bf0ad7a3bcd859b2be1d02dabd10657ebfa6190cbd3afb43bf0ad7a3bc20cd6dbe9e33a83d82107fbf201fc03c0aa696bf0ad7a33c23ba6fbe9949e1bd10657e3f8ef5a3bc63dd48bf0ad7a33c6dd11fbe61fbaa3d82107f3f00b9933c0aa696bf0ad7a3bc23ba6fbe16d3dfbd0f657ebf8060c1bc63dd48bf0ad7a3bc6dd11fbe7819ac3d83107fbf1c807a3c40dc98bf0ad7a33c1ee3f0bd6938e4bd11657e3fc3ae15bc56d04bbf0ad7a33c6a97a0bd4ac7ad3d83107f3f25f31f3c40dc98bf0ad7a3bc1ee3f0bd417ce3bd11657ebffa6151bc56d04bbf0ad7a3bc6a97a0bd0457ae3d82107fbf25b0e43b989999bf0ad7a33cbfb015b492f4e4bd10657e3f22f4ef3acbcc4cbf0ad7a33c5496c7b3c2e6ae3d82107f3f5a4db73a989999bf0ad7a3bcbfb015b491f4e4bd11657ebf22f4efbacbcc4cbf0ad7a3bc5496c7b3c2e6ae3d82107fbf5a4db7ba40dc98bf0ad7a33cf9e2f03d437ce3bd10657e3fa961513c56d04bbf0ad7a33c5197a03d0657ae3d83107f3ff8afe4bb40dc98bf0ad7a3bcf9e2f03d6a38e4bd11657ebf9aae153c56d04bbf0ad7a3bc5197a03d4ac7ad3d82107fbff6f21fbc0ba696bf0ad7a33c11ba6f3e18d3dfbd0f657e3f6d60c13c64dd48bf0ad7a33c61d11f3e7619ac3d83107f3fff7f7abc0ba696bf0ad7a3bc11ba6f3e9849e1bd11657ebf63f5a33c64dd48bf0ad7a3bc61d11f3e61fbaa3d82107fbf0ab993bc6cfc92bf0ad7a33cd059b23e1a02dabd11657e3fa4190c3d3afb43bf0ad7a33c15cd6d3e9d33a83d82107f3f2a1fc0bc6cfc92bf0ad7a3bcd059b23e5b2fdcbd11657ebf607ffb3c3afb43bf0ad7a3bc15cd6d3eec89a63d83107fbf3f0cd6bc6be88dbf0ad7a33ce01eeb3ea317d2bd10657e3fa929363de4353dbf0ad7a33c40bf9c3e12afa23d84107f3f4a9200bd6be88dbf0ad7a3bce01eeb3e40f6d4bd10657ebfa14e283de4353dbf0ad7a3bc40bf9c3ee57da03d84107fbfe7270bbd8d7687bf0ad7a33c22d0103f3a27c8bd11657e3f7f785e3d129e34bf0ad7a33c8315c13e70999b3d82107f3f11d81fbd8d7687bf0ad7a3bc22d0103f1eb0cbbd11657ebf953e513d129e34bf0ad7a3bc8315c13e2ce6983d82107fbfa3f229bd6d6d7fbf0ad7a33ccfab2a3f5149bcbd11657e3f7651823df3482abf0ad7a33cbe8fe33e3404933d82107f3fc2933dbd6d6d7fbf0ad7a3bccfab2a3fd373c0bd11657ebfab2a783df3482abf0ad7a3bcbe8fe33e80d58f3d83107fbf521a47bd02786dbf0ad7a33cb4e2423f3b9baebd10657e3f6125943d02501ebf0ad7a33c78ec013f8304893d84107f3f097c59bd02786dbf0ad7a3bcb4e2423f075db3bd10657ebf7d598e3d02501ebf0ad7a3bc78ec013f3862853d84107fbf2d5762bd223959bf0ad7a33c2039593fa73e9fbd11657e3f0b8ca43dc2d010bf0ad7a33cc0d0103fff657b3d83107f3f274c73bd223959bf0ad7a3bc2039593f0b8ca4bd11657ebfa73e9f3dc2d010bf0ad7a3bcc0d0103f274c733d83107fbfff657bbdb6e242bf0ad7a33c00786d3f79598ebd10657e3f085db33d7aec01bf0ad7a33c00501e3f3257623d84107f3f376285bdb6e242bf0ad7a3bc00786d3f5e2594bd10657ebf3b9bae3d7aec01bf0ad7a3bc00501e3f107c593d82107fbf800489bdd1ab2abf0ad7a33c6a6d7f3fb12a78bd10657e3fd073c03dc28fe3be0ad7a33cf2482a3f591a473d82107f3f81d58fbdd1ab2abf0ad7a3bc6a6d7f3f765182bd10657ebf5349bc3dc28fe3be0ad7a3bcf2482a3fc1933d3d83107fbf370493bd25d010bf0ad7a33c8c76873f9c3e51bd10657e3f1eb0cb3d8715c1be0ad7a33c109e343f9af2293d84107f3f30e698bd25d010bf0ad7a3bc8c76873f8a785ebd10657ebf3627c83d8715c1be0ad7a3bc109e343f0fd81f3d84107fbf73999bbde61eebbe0ad7a33c6ae88d3fa14e28bd10657e3f40f6d43d44bf9cbe0ad7a33ce2353d3fec270b3d83107f3fe47da0bde61eebbe0ad7a3bc6ae88d3fa72936bd11657ebfa217d23d44bf9cbe0ad7a3bce2353d3f5492003d82107fbf10afa2bdd659b2be0ad7a33c6bfc923f617ffbbc11657e3f5b2fdc3d1dcd6dbe0ad7a33c39fb433f4b0cd63c82107f3feb89a6bdd659b2be0ad7a3bc6bfc923fa5190cbd11657ebf1c02da3d1dcd6dbe0ad7a3bc39fb433f201fc03c82107fbf9d33a8bd1eba6fbe0ad7a33c0aa6963f8df5a3bc11657e3f9849e13d6ad11fbe0ad7a33c62dd483ffeb8933c83107f3f60fbaabd1eba6fbe0ad7a3bc0aa6963f7f60c1bc0f657ebf14d3df3d6ad11fbe0ad7a3bc62dd483f18807a3c83107fbf7619acbd16e3f0bd0ad7a33c40dc983fc3ae15bc11657e3f6838e43d6497a0bd0ad7a33c55d04b3f23f31f3c82107f3f48c7adbd16e3f0bd0ad7a3bc40dc983ffa6151bc11657ebf3f7ce33d6497a0bd0ad7a3bc55d04b3f25b0e43b82107fbf0457aebdf6aeb4b30ad7a33c9899993f22f4ef3a11657e3f91f4e43d48e970b30ad7a33ccacc4c3f584db73a82107f3fc0e6aebdf6aeb4b30ad7a3bc9899993f22f4efba11657ebf91f4e43d48e970b30ad7a3bccacc4c3f584db7ba82107fbfc0e6aebdffe2f03d0ad7a33c40dc983ff861513c11657e3f3e7ce33d5597a03d0ad7a33c55d04b3ff6afe4bb82107f3f0557aebdffe2f03d0ad7a3bc40dc983fc3ae153c11657ebf6838e43d5597a03d0ad7a3bc55d04b3ff6f21fbc82107fbf48c7adbd14ba6f3e0ad7a33c0aa6963f8060c13c0f657e3f17d3df3d62d11f3e0ad7a33c63dd483fec7f7abc83107f3f7819acbd14ba6f3e0ad7a3bc0aa6963f8df5a33c11657ebf9949e13d62d11f3e0ad7a3bc63dd483ff3b893bc82107fbf61fbaabdd159b23e0ad7a33c6bfc923fa5190c3d10657e3f1c02da3d16cd6d3e0ad7a33c3afb433f1f1fc0bc82107f3f9e33a8bdd159b23e0ad7a3bc6bfc923f637ffb3c10657ebf5d2fdc3d16cd6d3e0ad7a3bc3afb433f4d0cd6bc83107fbff089a6bde11eeb3e0ad7a33c6ae88d3f9729363d10657e3fa717d23d41bf9c3e0ad7a33ce3353d3f569200bd84107f3f13afa2bde11eeb3e0ad7a3bc6ae88d3f984e283d10657ebf43f6d43d41bf9c3e0ad7a3bce3353d3fee270bbd83107fbfe77da0bd23d0103f0ad7a33c8d76873f80785e3d10657e3f3927c83d8415c13e0ad7a33c119e343f14d81fbd83107f3f71999bbd23d0103f0ad7a3bc8d76873f883e513d11657ebf1fb0cb3d8415c13e0ad7a3bc119e343fa6f229bd83107fbf2de698bdcfab2a3f0ad7a33c6c6d7f3f7951823d11657e3f5049bc3dbe8fe33e0ad7a33cf2482a3fc5933dbd83107f3f330493bdcfab2a3f0ad7a3bc6c6d7f3fb52a783d11657ebfd073c03dbe8fe33e0ad7a3bcf2482a3f531a47bd82107fbf7ed58fbdb4e2423f0ad7a33c01786d3f6125943d10657e3f3b9bae3d78ec013f0ad7a33c01501e3f097c59bd84107f3f830489bdb4e2423f0ad7a3bc01786d3f7d598e3d10657ebf075db33d78ec013f0ad7a3bc01501e3f2d5762bd84107fbf386285bd2039593f0ad7a33c2139593f0b8ca43d11657e3fa73e9f3dc0d0103f0ad7a33cc1d0103f274c73bd83107f3fff657bbd2039593f0ad7a3bc2139593fa73e9f3d11657ebf0b8ca43dc0d0103f0ad7a3bcc1d0103fff657bbd83107fbf274c73bd00786d3f0ad7a33cb5e2423f085db33d10657e3f79598e3d00501e3f0ad7a33c79ec013f376285bd84107f3f325762bd00786d3f0ad7a3bcb5e2423f3b9bae3d10657ebf5e25943d00501e3f0ad7a3bc79ec013f800489bd82107fbf107c59bd6a6d7f3f0ad7a33cd0ab2a3fd073c03d10657e3fb12a783df2482a3f0ad7a33cc08fe33e80d58fbd84107f3f5c1a47bd6a6d7f3f0ad7a3bcd0ab2a3f5349bc3d10657ebf7651823df2482a3f0ad7a3bcc08fe33e350493bd83107fbfc2933dbd8c76873f0ad7a33c24d0103f20b0cb3d10657e3f9e3e513d109e343f0ad7a33c8615c13e2de698bd84107f3f9af229bd8c76873f0ad7a3bc24d0103f3527c83d11657ebf89785e3d109e343f0ad7a3bc8615c13e74999bbd84107fbf0fd81fbd6ae88d3f0ad7a33ce41eeb3e41f6d43d11657e3fa04e283de2353d3f0ad7a33c42bf9c3ee47da0bd83107f3fea270bbd6ae88d3f0ad7a3bce41eeb3ea317d23d11657ebfa729363de2353d3f0ad7a3bc42bf9c3e11afa2bd82107fbf549200bd6bfc923f0ad7a33cd359b23e592fdc3d11657e3f617ffb3c39fb433f0ad7a33c1acd6d3eec89a6bd82107f3f4d0cd6bc6bfc923f0ad7a3bcd359b23e1c02da3d11657ebfa5190c3d39fb433f0ad7a3bc1acd6d3e9b33a8bd82107fbf1d1fc0bc0aa6963f0ad7a33c1aba6f3e9749e13d11657e3f8cf5a33c62dd483f0ad7a33c66d11f3e60fbaabd83107f3ffeb893bc0aa6963f0ad7a3bc1aba6f3e15d3df3d0f657ebf8060c13c62dd483f0ad7a3bc66d11f3e7619acbd82107fbf1a807abc40dc983f0ad7a33c0ce3f03d6838e43d11657e3f64af153c55d04b3f0ad7a33c5e97a03d46c7adbd82107f3f67f31fbc40dc983f0ad7a3bc0ce3f03d3d7ce33d11657ebf4762513c55d04b3f0ad7a3bc5e97a03d0457aebd83107fbf3cb1e4bb
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.00000011920929, y: 0, z: -0.000000059604645}
+    m_Extent: {x: 1.1999999, y: 0.02, z: 1.1999998}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &1611708410
 GameObject:
   m_ObjectHideFlags: 0
@@ -21201,6 +33680,36 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1624091896}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &1624411946
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000013882991340, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1624411947}
+  m_Layer: 0
+  m_Name: Middle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1624411947
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000013359975326, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1624411946}
+  m_LocalRotation: {x: 0.825906, y: -0.016493322, z: -0.09523392, w: -0.5554619}
+  m_LocalPosition: {x: -0.239468, y: 1.5695634, z: 1.19417}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1627801426
 GameObject:
   m_ObjectHideFlags: 0
@@ -21345,6 +33854,80 @@ Transform:
   m_Father: {fileID: 993634892}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1637684299
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1637684300}
+  - component: {fileID: 1637684302}
+  - component: {fileID: 1637684301}
+  m_Layer: 0
+  m_Name: It's some very cool suff
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1637684300
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1637684299}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 30
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1637684301
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1637684299}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 2022802837}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &1637684302
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1637684299}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: SkipMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: TryWidget
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1638152485
 Prefab:
   m_ObjectHideFlags: 0
@@ -21416,6 +33999,603 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad,
     type: 3}
   m_PrefabInternal: {fileID: 1638152485}
+--- !u!1 &1638628140
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000013079249492, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1638628141}
+  m_Layer: 0
+  m_Name: Index Sphere Body R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1638628141
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000014090360156, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1638628140}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0, y: 0, z: 0.0036}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 45922386}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1642519554
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1642519555}
+  - component: {fileID: 1642519557}
+  - component: {fileID: 1642519556}
+  m_Layer: 0
+  m_Name: Capsule (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1642519555
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1642519554}
+  m_LocalRotation: {x: 0.7071068, y: 0.0000000124929596, z: 0.00000002366883, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0.0062, z: 0.0114}
+  m_LocalScale: {x: 0.004940001, y: 0.008603162, z: 0.00494}
+  m_Children: []
+  m_Father: {fileID: 1373595205}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!23 &1642519556
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1642519554}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: e485cb7dc76a9eb4fac7bf614dc93eb7, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1642519557
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1642519554}
+  m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1648580832
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1233535996592886, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1648580833}
+  - component: {fileID: 1648580835}
+  - component: {fileID: 1648580834}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1648580833
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4407909636905154, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1648580832}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.17366949, y: -0.014609394, z: 0.48384488}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1455914325}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1648580834
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23788642171260438, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1648580832}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1648580835
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33604702829729378, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1648580832}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1649983739
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1649983740}
+  - component: {fileID: 1649983742}
+  - component: {fileID: 1649983744}
+  - component: {fileID: 1649983743}
+  - component: {fileID: 1649983741}
+  m_Layer: 0
+  m_Name: Tutorial Bot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1649983740
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1649983739}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1018588569}
+  - {fileID: 959373736}
+  - {fileID: 1311336093}
+  - {fileID: 181722601}
+  - {fileID: 1050640148}
+  m_Father: {fileID: 0}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1649983741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1649983739}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 48b9319bebe11354782ce29c51135bcd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  tracksToWatch:
+  - Tutorial Bot
+  drawGizmoOnDiscontinuity: 1
+  gizmoLocation: {fileID: 1018588569}
+--- !u!320 &1649983742
+PlayableDirector:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1649983739}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_PlayableAsset: {fileID: 11400000, guid: e5e65174dee4d0b41adab613d7b3d4fb, type: 2}
+  m_InitialState: 1
+  m_WrapMode: 2
+  m_DirectorUpdateMode: 1
+  m_InitialTime: 14
+  m_SceneBindings:
+  - key: {fileID: 114217824934984836, guid: b20f351b7ff64ce44a8c96d992a5fa44, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114474560350453430, guid: b20f351b7ff64ce44a8c96d992a5fa44, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114626585810784762, guid: ffdd464ddcfd10f49a9cb05296f177ab, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114648228133821994, guid: ffdd464ddcfd10f49a9cb05296f177ab, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114741107710073536, guid: 7b7e5f52f8ae38e47ad43ebebe7dfa63, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114347167062738160, guid: 7b7e5f52f8ae38e47ad43ebebe7dfa63, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114741107710073536, guid: 28e4d5da82253714a9b9d766192a698d, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114347167062738160, guid: 28e4d5da82253714a9b9d766192a698d, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114741107710073536, guid: bfc84f3f3dba026489a0760bf16dbcf5, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114347167062738160, guid: bfc84f3f3dba026489a0760bf16dbcf5, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114741107710073536, guid: 2fb7f53bb823b324489de31ef3c41de5, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114347167062738160, guid: 2fb7f53bb823b324489de31ef3c41de5, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114741107710073536, guid: 63fc45df1cbbaca4b9d5a8945e4abd4a, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114347167062738160, guid: 63fc45df1cbbaca4b9d5a8945e4abd4a, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114741107710073536, guid: 041c6afebdca8bc44948ea6af7307a13, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114347167062738160, guid: 041c6afebdca8bc44948ea6af7307a13, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114741107710073536, guid: 172b303690f69be44bba7a909ac11fb7, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114347167062738160, guid: 172b303690f69be44bba7a909ac11fb7, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114867793862046712, guid: 172b303690f69be44bba7a909ac11fb7, type: 2}
+    value: {fileID: 1259462723}
+  - key: {fileID: 114921765267057228, guid: ffdd464ddcfd10f49a9cb05296f177ab, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114266143016834320, guid: cba970acc82c21c4887dd4675bb0f3fd, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114726847761050726, guid: bfc84f3f3dba026489a0760bf16dbcf5, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114543813658732134, guid: 2fb7f53bb823b324489de31ef3c41de5, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114630114126635508, guid: 63fc45df1cbbaca4b9d5a8945e4abd4a, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114347754607478672, guid: 041c6afebdca8bc44948ea6af7307a13, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114842188575970174, guid: 172b303690f69be44bba7a909ac11fb7, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114766288454915334, guid: 68d4f3cfa327bb444b0feecdb1672fd1, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114440329120741648, guid: 68d4f3cfa327bb444b0feecdb1672fd1, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114199658763684046, guid: 8011ee1000fb4684eaa2b53683c9c9b3, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114529183623213518, guid: 8011ee1000fb4684eaa2b53683c9c9b3, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114339773767688754, guid: cf577d509cf1547468a2f3efeff78a3f, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 0}
+    value: {fileID: 94561690}
+  - key: {fileID: 114242868819644202, guid: dd6cdabe8a3991f499cb42cf4ec1f8fe, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114261289236674188, guid: dd6cdabe8a3991f499cb42cf4ec1f8fe, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114010498409069402, guid: 509299671b11e894297166a6cdcaee92, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114206912546067078, guid: 509299671b11e894297166a6cdcaee92, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114010498409069402, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114206912546067078, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114992523939886968, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1259462723}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114705164115353276, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114094380375306384, guid: 1c563e2e8f118d144a7ea88e278018ad, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114735441203811238, guid: 021124642d702a54885d196ba1dcb622, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114103428291997588, guid: 021124642d702a54885d196ba1dcb622, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114771375372277946, guid: 021124642d702a54885d196ba1dcb622, type: 2}
+    value: {fileID: 1259462723}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114263579248006170, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114128832824185654, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114310563169378314, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1259462723}
+  - key: {fileID: 114599883978458556, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114312170612696854, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114522747698900880, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114724076256103096, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1259462723}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114852558391976422, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114037899812834644, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114260385365746808, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 1259462723}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114634801097913166, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114046373491883722, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114601425486478188, guid: 71c4787e5273018478a550624a8077a2, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114349828668051278, guid: 8011ee1000fb4684eaa2b53683c9c9b3, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114174879659835672, guid: 072e18c3ad34ec74b92a37b1fee7ead8, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114279283812818858, guid: 072e18c3ad34ec74b92a37b1fee7ead8, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114713067825342526, guid: e1983c6ba9fe05c48bc22a575c41c0d1, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114954626801235504, guid: e1983c6ba9fe05c48bc22a575c41c0d1, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114056199570382756, guid: 17e41049430064d4c952a87c969e4c98, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114436618508812636, guid: 17e41049430064d4c952a87c969e4c98, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114957679048667368, guid: 17e41049430064d4c952a87c969e4c98, type: 2}
+    value: {fileID: 1675334813}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114143029704313322, guid: e1983c6ba9fe05c48bc22a575c41c0d1, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114425158812268760, guid: 072e18c3ad34ec74b92a37b1fee7ead8, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114236683185265888, guid: e1983c6ba9fe05c48bc22a575c41c0d1, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114571911065793380, guid: e1983c6ba9fe05c48bc22a575c41c0d1, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114989776473446960, guid: 17e41049430064d4c952a87c969e4c98, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114029893116248002, guid: 5f69b7c7a87058d4580e04a478815607, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114479975236912908, guid: 5f69b7c7a87058d4580e04a478815607, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114618983960947318, guid: 1b71ced2c6ac3394db0545294040bf48, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114365951381046438, guid: 1b71ced2c6ac3394db0545294040bf48, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114306054635708908, guid: 2924a985932277e4f9869d1e4a26a5fb, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114170280259348484, guid: 2924a985932277e4f9869d1e4a26a5fb, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114968412315773482, guid: 2924a985932277e4f9869d1e4a26a5fb, type: 2}
+    value: {fileID: 1373135256}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114898729818865182, guid: 2924a985932277e4f9869d1e4a26a5fb, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114249772511729240, guid: 1b71ced2c6ac3394db0545294040bf48, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114906409046192762, guid: 5f69b7c7a87058d4580e04a478815607, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114649190117733080, guid: 1b71ced2c6ac3394db0545294040bf48, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114660165107599574, guid: 1b71ced2c6ac3394db0545294040bf48, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114918159718576022, guid: 4bdd32b218fd3a8449c0d79347336c10, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114092283620818140, guid: 4bdd32b218fd3a8449c0d79347336c10, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114764893742295864, guid: 4bdd32b218fd3a8449c0d79347336c10, type: 2}
+    value: {fileID: 351986687}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114321043124189922, guid: 4bdd32b218fd3a8449c0d79347336c10, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114869871952279424, guid: 4bdd32b218fd3a8449c0d79347336c10, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114606155883913206, guid: 4bdd32b218fd3a8449c0d79347336c10, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114086737397741816, guid: 058111a9d90a4f043bc9b61354670d93, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114357275685725694, guid: 058111a9d90a4f043bc9b61354670d93, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114490814460295048, guid: 058111a9d90a4f043bc9b61354670d93, type: 2}
+    value: {fileID: 318198445}
+  - key: {fileID: 0}
+    value: {fileID: 0}
+  - key: {fileID: 114190676117979244, guid: 058111a9d90a4f043bc9b61354670d93, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114309695710675490, guid: 058111a9d90a4f043bc9b61354670d93, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114840310413029850, guid: 058111a9d90a4f043bc9b61354670d93, type: 2}
+    value: {fileID: 0}
+  - key: {fileID: 114964535364365634, guid: e5e65174dee4d0b41adab613d7b3d4fb, type: 2}
+    value: {fileID: 1649983739}
+  - key: {fileID: 114826077641207146, guid: e5e65174dee4d0b41adab613d7b3d4fb, type: 2}
+    value: {fileID: 94561690}
+  - key: {fileID: 114129299740152972, guid: e5e65174dee4d0b41adab613d7b3d4fb, type: 2}
+    value: {fileID: 0}
+  m_ExposedReferences:
+    m_References:
+    - 023e1542c65502c4f8397f4ede37458c: {fileID: 1840705450}
+    - 8a0d34dc5b67b28459b71cc16749cb7f: {fileID: 1840705450}
+    - 8ae17144d3722654ab202f6ce312c217: {fileID: 1840705450}
+    - 260b479e200d94e4089095171309fe67: {fileID: 1840705450}
+    - d27ea0ff07874cb4182d7c644d598168: {fileID: 1840705450}
+    - 5153f0bfbd13bb5438f4631c68bc833e: {fileID: 1840705450}
+    - e3264c720b4f3ba4bbcc59dab7debf7a: {fileID: 1840705450}
+    - c716adab998850d47b5f19f0df6c66af: {fileID: 1840705450}
+    - 3ca6737c5575f1649bc555f77a3d9038: {fileID: 1840705450}
+    - f4c46288870abf44694455e7ca6439c0: {fileID: 1840705450}
+    - 378cb4b8cd71f76439787d1f6ed66806: {fileID: 1840705450}
+    - 86ed5b5bbd8714a4ebf0cc5065e10809: {fileID: 1840705450}
+    - bdc3f0c5c75951641be0f44cc6f6ad3d: {fileID: 1840705450}
+    - 6062d62ea4f098e4ba08c74ba62cce96: {fileID: 1649983739}
+    - 4b36b1c05466fa448b5c96943750f1e7: {fileID: 1840705450}
+    - 155bd8d4801fc5046ad0df04a7f9f5ac: {fileID: 1840705450}
+    - e67015423cfc1c1479447278d821c170: {fileID: 1840705450}
+    - 78d1ace861ce8774d960fa30bb1dbc30: {fileID: 1840705450}
+    - 20a03641a30f5ce4888ff52c914f6800: {fileID: 1840705450}
+    - 98dbd003d4b352744b48903cfe602896: {fileID: 1840705450}
+    - 12c7d6dd508d6b94490213c4d5a42b72: {fileID: 1840705450}
+    - 1beb9f077d25d9241970f0e622ebaf93: {fileID: 1840705450}
+    - ad7ed3c84fae07b4e8849bc1e33309ee: {fileID: 1840705450}
+    - 523392fefde89aa4f966de48b68b7b76: {fileID: 1840705450}
+    - 6e620706c28387740a884c70e58f97db: {fileID: 1840705450}
+    - 1f2a0ddb0c72cbc48aa977133db8bcb2: {fileID: 1840705450}
+    - 2f18afd7e5e7d1544b22ffdad4e3e034: {fileID: 1840705450}
+    - 858d6f0b2fa2fd84f9717596a321584d: {fileID: 1840705450}
+    - bdf3104245db9c640a83447cbab41773: {fileID: 1840705450}
+    - b630a38a193799b458bc8ac000d967ca: {fileID: 1840705450}
+    - f4f52d1827f08f448a99b8101bcb6004: {fileID: 1840705450}
+    - e8a854197de20d7408051a95e87e728a: {fileID: 1840705450}
+    - f90573edc2f4ca74ab2c887dc264c86e: {fileID: 1840705450}
+    - ecd53d9eedd2c5149a25a2db3e5a72bd: {fileID: 1840705450}
+    - 0aa0acf02c7fd1d4198da1ecf24870d0: {fileID: 1840705450}
+    - bc60c94fc89121441833b0ba7049528b: {fileID: 1840705450}
+    - c659a8c0b81a7884f8a7c0ba5aa4f888: {fileID: 1840705450}
+    - 018637785f65ebe499117daaf8b5510b: {fileID: 1840705450}
+    - c3182fd7e1cc1d04091cf50474a9973d: {fileID: 1840705450}
+    - 5b378522446413141b175e00fd5bfafb: {fileID: 1840705450}
+    - 296937c1cd4af584698baeb31a275b09: {fileID: 1840705450}
+    - 498f77eccc73e5d44bdf77ae71535fdf: {fileID: 1840705450}
+    - 0260ff38923b29448a577177cdab4b42: {fileID: 1840705450}
+    - 977f0d92a7d9e934c9549d9b4c9127b6: {fileID: 1840705450}
+    - d0631810c46b2d141915b426f2673421: {fileID: 1840705450}
+    - 5bd84cabb8bb3b846a0481d0ce569e03: {fileID: 1840705450}
+    - 4ae08894a059ea9468b9e584470dfab8: {fileID: 1840705450}
+    - 996cc904d026ea54197cd64e6a70b4f8: {fileID: 1840705450}
+    - 21c8a0e0f368f76448791df03450777f: {fileID: 1840705450}
+    - a6f1bb7dad4097f4ba6ab36767da17c8: {fileID: 1840705450}
+    - eaad583bbfe3e69469a6f9d6f4b6d615: {fileID: 1840705450}
+    - 101fc155f47fbf044998834cc65be641: {fileID: 1840705450}
+    - 65b658ef1d299554ab11eba77d616cb7: {fileID: 1840705450}
+    - 0a9ab96c3dda03d46818ff4c0b4ef68d: {fileID: 1840705450}
+    - fa40bc2461f832248907691344fde3ff: {fileID: 1840705450}
+    - 5dd41827d16597d4bab78b0b585338d4: {fileID: 1840705450}
+    - 3247c225fe6bdcc4bb03733efa44f44b: {fileID: 1840705450}
+    - a5579fc9ca4c49d40bbd9dfc7c7c2cb3: {fileID: 1840705450}
+    - 74be518cb6b21b141816f058cc170169: {fileID: 1840705450}
+    - 657b40e40dfa7884c9ddbd501a35795b: {fileID: 1840705450}
+    - 93e7a5f6bcae8e54ca6963b6ee762619: {fileID: 1840705450}
+    - f546e254fd510fc4183c294f345216dc: {fileID: 1840705450}
+    - 9108871aa9a7bf64897ed4fe5901c9b8: {fileID: 1840705450}
+    - b5a99dca685a11640a77e8ba1c855154: {fileID: 1840705450}
+    - eb52087d70a3ca84b885054dd3594ea1: {fileID: 1840705450}
+    - 2b3a15adf4549a44daf753f896e5d96b: {fileID: 1840705450}
+    - b0e9a122ec237c3428bdfb382f8d9ba4: {fileID: 1840705450}
+    - e7542e3f781b819469b2bdef9e610d42: {fileID: 1840705450}
+    - a0fb29447ec66e34a87c4a040c72d0d2: {fileID: 1840705450}
+    - a7dca105b7a23e949b5c3487cd6311ba: {fileID: 1840705450}
+    - 5806297049b5d1643aaba5b14e3f0a8e: {fileID: 1840705450}
+    - dc4d3fcc370841b4a9e2b5b276124ada: {fileID: 1840705450}
+--- !u!114 &1649983743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1649983739}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f7ca330565001694a966a1c1363d7dd1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!95 &1649983744
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1649983739}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 1aa8339583a8a5244bd7e1010bcbc4a7, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
 --- !u!1001 &1651502693
 Prefab:
   m_ObjectHideFlags: 0
@@ -21478,6 +34658,36 @@ Prefab:
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 224b0c2601c67cc46871bb1c660ef3d8, type: 3}
   m_IsPrefabParent: 0
+--- !u!1 &1655177876
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1655177877}
+  m_Layer: 0
+  m_Name: Paint Cursor R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1655177877
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1655177876}
+  m_LocalRotation: {x: -0.16046898, y: -0.022173751, z: 0.122600265, w: 0.9791462}
+  m_LocalPosition: {x: -0.0251, y: -0.0527, z: 0.0281}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2069969048}
+  - {fileID: 1458460965}
+  m_Father: {fileID: 1948795073}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -17.94, y: -4.8500004, z: 14.7560005}
 --- !u!43 &1659321585
 Mesh:
   m_ObjectHideFlags: 3
@@ -21564,7 +34774,7 @@ Mesh:
       format: 0
       dimension: 0
     m_DataSize: 880
-    _typelessdata: 840773bc5c1db43a000000000000803f0000803f0000803f0000803f0000a43d00000a3f0000000000000000ca2f16bc5c1db43a000000000000803f0000803f0000803f0000803f0000e83d00000a3f0000000000000000ca2f16bc2045c3bb000000000000803f0000803f0000803f0000803f0000e83d0000153f0000000000000000840773bc2045c3bb000000000000803f0000803f0000803f0000803f0000a43d0000153f0000000000000000b1b910bc84f9723b000000000000803f0000803f0000803f0000803f0000a43d0000153f0000000000000000c211cabb84f9723b000000000000803f0000803f0000803f0000803f0000c43d0000153f0000000000000000c211cabbec58b8bb000000000000803f0000803f0000803f0000803f0000c43d0000233f0000000000000000b1b910bcec58b8bb000000000000803f0000803f0000803f0000803f0000a43d0000233f00000000000000008f25bfbb5c1db43a000000000000803f0000803f0000803f0000803f0000e83d0000f23e000000000000000000745a3a5c1db43a000000000000803f0000803f0000803f0000803f00001c3e0000f23e000000000000000000745a3a2045c3bb000000000000803f0000803f0000803f0000803f00001c3e0000043f00000000000000008f25bfbb2045c3bb000000000000803f0000803f0000803f0000803f0000e83d0000043f0000000000000000fe735a3a5c1db43a000000000000803f0000803f0000803f0000803f0000043e0000043f00000000000000005bd6ea3b5c1db43a000000000000803f0000803f0000803f0000803f00002a3e0000043f00000000000000005bd6ea3b2045c3bb000000000000803f0000803f0000803f0000803f00002a3e00000f3f0000000000000000fe735a3a2045c3bb000000000000803f0000803f0000803f0000803f0000043e00000f3f00000000000000006157003c5c1db43a000000000000803f0000803f0000803f0000803f0000b53e0000b93e000000000000000068916d3c5c1db43a000000000000803f0000803f0000803f0000803f0000c93e0000b93e000000000000000068916d3cec58b8bb000000000000803f0000803f0000803f0000803f0000c93e0000ce3e00000000000000006157003cec58b8bb000000000000803f0000803f0000803f0000803f0000b53e0000ce3e0000000000000000
+    _typelessdata: 840773bc5c1db43a000000000000803f0000803f0000803f0000803f00005c3f00008f3e0000000000000000ca2f16bc5c1db43a000000000000803f0000803f0000803f0000803f0080643f00008f3e0000000000000000ca2f16bc2045c3bb000000000000803f0000803f0000803f0000803f0080643f0000a53e0000000000000000840773bc2045c3bb000000000000803f0000803f0000803f0000803f00005c3f0000a53e0000000000000000b1b910bc84f9723b000000000000803f0000803f0000803f0000803f0000703f0000803e0000000000000000c211cabb84f9723b000000000000803f0000803f0000803f0000803f0000743f0000803e0000000000000000c211cabbec58b8bb000000000000803f0000803f0000803f0000803f0000743f00009c3e0000000000000000b1b910bcec58b8bb000000000000803f0000803f0000803f0000803f0000703f00009c3e00000000000000008f25bfbb5c1db43a000000000000803f0000803f0000803f0000803f0000f83e0000b23e000000000000000000745a3a5c1db43a000000000000803f0000803f0000803f0000803f0000063f0000b23e000000000000000000745a3a2045c3bb000000000000803f0000803f0000803f0000803f0000063f0000c83e00000000000000008f25bfbb2045c3bb000000000000803f0000803f0000803f0000803f0000f83e0000c83e0000000000000000fe735a3a5c1db43a000000000000803f0000803f0000803f0000803f0080753f0000963e00000000000000005bd6ea3b5c1db43a000000000000803f0000803f0000803f0000803f00007f3f0000963e00000000000000005bd6ea3b2045c3bb000000000000803f0000803f0000803f0000803f00007f3f0000ac3e0000000000000000fe735a3a2045c3bb000000000000803f0000803f0000803f0000803f0080753f0000ac3e00000000000000006157003c5c1db43a000000000000803f0000803f0000803f0000803f0000663f0000b53e000000000000000068916d3c5c1db43a000000000000803f0000803f0000803f0000803f0000703f0000b53e000000000000000068916d3cec58b8bb000000000000803f0000803f0000803f0000803f0000703f0000ca3e00000000000000006157003cec58b8bb000000000000803f0000803f0000803f0000803f0000663f0000ca3e0000000000000000
   m_CompressedMesh:
     m_Vertices:
       m_NumItems: 0
@@ -21777,7 +34987,7 @@ MonoBehaviour:
   OnRelease:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2085845412}
+      - m_Target: {fileID: 0}
         m_MethodName: SetCursorFollowDynamic
         m_Mode: 1
         m_Arguments:
@@ -21880,6 +35090,141 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad,
     type: 3}
   m_PrefabInternal: {fileID: 1669978112}
+--- !u!1 &1671806021
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1671806022}
+  m_Layer: 0
+  m_Name: '--------'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1671806022
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1671806021}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 32
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1675334811
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1315479071886288, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1675334812}
+  - component: {fileID: 1675334816}
+  - component: {fileID: 1675334815}
+  - component: {fileID: 1675334814}
+  - component: {fileID: 1675334813}
+  m_Layer: 0
+  m_Name: Thick Ribbon Renderer (palm tree)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1675334812
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4200987617497462, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1675334811}
+  m_LocalRotation: {x: -0, y: 1, z: -0, w: 0.0000023990867}
+  m_LocalPosition: {x: 0, y: 0.559, z: 1.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 137824214}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1675334813
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114913891726267932, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1675334811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a556b57af5586b4dbefb616d1d34b4c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  data: {fileID: 11400000, guid: 7fd0e09f11e39cc458dc69992d94d3bf, type: 2}
+  clipTime: 29.266666
+--- !u!114 &1675334814
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 114625929350600168, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1675334811}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 41ee06f17d023954c9ea5105af0e174a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _ribbonMaterial: {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  _finalizedRibbonParent: {fileID: 181722600}
+  registerWithHistoryManager: 0
+--- !u!33 &1675334815
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33343224749167078, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1675334811}
+  m_Mesh: {fileID: 0}
+--- !u!23 &1675334816
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23385238376784644, guid: cf858cdc2755e29469bed8d51610e062,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1675334811}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 82c3cb2a8db33a6419e30ad96b091289, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &1676268084
 GameObject:
   m_ObjectHideFlags: 0
@@ -21933,6 +35278,82 @@ Material:
     m_Floats: []
     m_Colors:
     - _Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &1685115187
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000974563528780, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1685115188}
+  - component: {fileID: 1685115190}
+  - component: {fileID: 1685115189}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1685115188
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4248235038059940, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1685115187}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.037442762, y: 0.19100341, z: -0.06721868}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1094083028}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1685115189
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23746514979787986, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1685115187}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1685115190
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33965266918879848, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1685115187}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &1693292744
 GameObject:
   m_ObjectHideFlags: 0
@@ -22107,6 +35528,161 @@ MonoBehaviour:
   _buttonRenderer: {fileID: 621030492}
   _normalColor: {r: 0.8745098, g: 0.8745098, b: 0.8745098, a: 1}
   _pressedColor: {r: 0.59607846, g: 0.59607846, b: 0.59607846, a: 1}
+--- !u!1001 &1702601570
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1293942366}
+    m_Modifications:
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalRotation.x
+      value: 0.000000115202326
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalRotation.y
+      value: -0.7071067
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalRotation.z
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalRotation.w
+      value: -0.00000011520231
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: _showArm
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: _material
+      value: 
+      objectReference: {fileID: 2100000, guid: 92fa5c69aadc37442aecefee438af7f3, type: 2}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: _sphereMesh
+      value: 
+      objectReference: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: _cylinderResolution
+      value: 24
+      objectReference: {fileID: 0}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: _materialNonGhostable
+      value: 
+      objectReference: {fileID: 2100000, guid: 7eed02a120bdd6e499824de34730957d, type: 2}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: _materialGhostable
+      value: 
+      objectReference: {fileID: 2100000, guid: 92fa5c69aadc37442aecefee438af7f3, type: 2}
+    - target: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: useGhostable
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+  m_IsPrefabParent: 0
+--- !u!4 &1702601571 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+  m_PrefabInternal: {fileID: 1702601570}
+--- !u!114 &1702601572 stripped
+MonoBehaviour:
+  m_PrefabParentObject: {fileID: 11407378, guid: 869d20cdda15af24aab9e72b5f2eec78,
+    type: 2}
+  m_PrefabInternal: {fileID: 1702601570}
+  m_Script: {fileID: 11500000, guid: a04122797dd84ca43a07055f12d91e0f, type: 3}
+--- !u!1 &1706391412
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1706391413}
+  - component: {fileID: 1706391415}
+  - component: {fileID: 1706391414}
+  m_Layer: 0
+  m_Name: Give thumbs up to continue
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1706391413
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1706391412}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 26
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1706391414
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1706391412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 715153d525c322e47890cc24adb976b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1541230323}
+  transitionState: {fileID: 222778846}
+  withinAngle: 70
+  forDuration: 1
+--- !u!114 &1706391415
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1706391412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: SetText
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: Give me the thumbs up when you are ready to move on!
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1 &1713871138
 GameObject:
   m_ObjectHideFlags: 0
@@ -22178,6 +35754,172 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d451ada4afad3af459e596f8ae6f053d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1715423706
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1234122383256208, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1715423707}
+  - component: {fileID: 1715423709}
+  - component: {fileID: 1715423708}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1715423707
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4614325693171608, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1715423706}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.004258338, y: 0.6258001, z: -0.08682187}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 1445655200}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1715423708
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23271667964735148, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1715423706}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1715423709
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33326277673625176, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1715423706}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1719081241
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1719081242}
+  - component: {fileID: 1719081245}
+  - component: {fileID: 1719081244}
+  - component: {fileID: 1719081243}
+  m_Layer: 0
+  m_Name: Give thumbs up!
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1719081242
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1719081241}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1719081243
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1719081241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 715153d525c322e47890cc24adb976b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 582206189}
+  transitionState: {fileID: 222778846}
+  withinAngle: 70
+  forDuration: 0.4
+--- !u!114 &1719081244
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1719081241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 1c563e2e8f118d144a7ea88e278018ad, type: 2}
+  _wrapMode: 1
+--- !u!114 &1719081245
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1719081241}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: ClearText
+            m_Mode: 1
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: 
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1726015396
 Prefab:
   m_ObjectHideFlags: 0
@@ -22301,7 +36043,7 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1730915496}
-  m_Mesh: {fileID: 1348381171}
+  m_Mesh: {fileID: 24147754}
 --- !u!23 &1730915500
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -22514,6 +36256,143 @@ Texture2D:
     offset: 0
     size: 0
     path: 
+--- !u!1 &1737902597
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1737902598}
+  - component: {fileID: 1737902600}
+  - component: {fileID: 1737902599}
+  m_Layer: 0
+  m_Name: Now I'm gonna draw a face
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1737902598
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1737902597}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 22
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1737902599
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1737902597}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 693536396}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &1737902600
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1737902597}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 2924a985932277e4f9869d1e4a26a5fb, type: 2}
+  _wrapMode: 2
+--- !u!1 &1738942288
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1530941648300860, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1738942289}
+  - component: {fileID: 1738942291}
+  - component: {fileID: 1738942290}
+  m_Layer: 0
+  m_Name: Mixing Basin Liquid
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1738942289
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4072016716846474, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1738942288}
+  m_LocalRotation: {x: -6.123234e-17, y: 1, z: 6.123234e-17, w: -3.7493994e-33}
+  m_LocalPosition: {x: 0, y: 0.103, z: 0}
+  m_LocalScale: {x: 0.3534555, y: 0.3922811, z: 0.35345528}
+  m_Children:
+  - {fileID: 652610720}
+  - {fileID: 1529389051}
+  - {fileID: 1756967075}
+  m_Father: {fileID: 1509140293}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1738942290
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23173212790085832, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1738942288}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 2055dc432d0c5884e8bcd58f42cee094, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1738942291
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33210858843911824, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1738942288}
+  m_Mesh: {fileID: 4300000, guid: 06b31ad3b87bb7b45a76168724c4eb00, type: 3}
 --- !u!1 &1739032487
 GameObject:
   m_ObjectHideFlags: 0
@@ -22671,6 +36550,114 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+--- !u!1 &1739818861
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1628871032169758, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1739818862}
+  - component: {fileID: 1739818864}
+  - component: {fileID: 1739818863}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1739818862
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4148246409516246, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739818861}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.0869676, y: 0.2152003, z: 0.057885524}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 2079904826}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1739818863
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23814548273974840, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739818861}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1739818864
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33157988660520268, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1739818861}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1743175001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1204450125606888, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1743175002}
+  m_Layer: 0
+  m_Name: Color Swatch (19)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1743175002
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4425597189850868, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1743175001}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 0.41547203, y: 2.6, z: -0.78}
+  m_LocalScale: {x: 0.38721097, y: 0.3872097, z: 0.38721007}
+  m_Children:
+  - {fileID: 2009537890}
+  - {fileID: 91909876}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 20
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1750258683
 GameObject:
   m_ObjectHideFlags: 0
@@ -22912,6 +36899,36 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 1755809132}
+--- !u!1 &1756967074
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1265263289059470, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1756967075}
+  m_Layer: 0
+  m_Name: Box Collider (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1756967075
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4067677950802336, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1756967074}
+  m_LocalRotation: {x: -0.000000018626451, y: 0.51202583, z: 0.0000000037252903, w: 0.8589701}
+  m_LocalPosition: {x: -0.0600001, y: 0.029997999, z: -0.1600015}
+  m_LocalScale: {x: 5.1319556, y: 0.2857803, z: 5.131955}
+  m_Children: []
+  m_Father: {fileID: 1738942289}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 61.646004, z: 0}
 --- !u!1 &1757328762
 GameObject:
   m_ObjectHideFlags: 0
@@ -23115,6 +37132,95 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1769069603}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &1774235339
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1774235340}
+  - component: {fileID: 1774235343}
+  - component: {fileID: 1774235342}
+  - component: {fileID: 1774235341}
+  m_Layer: 0
+  m_Name: Farewell
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1774235340
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1774235339}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 33
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1774235341
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1774235339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1191593141}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &1774235342
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1774235339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: e5e65174dee4d0b41adab613d7b3d4fb, type: 2}
+  _wrapMode: 2
+--- !u!114 &1774235343
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1774235339}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: EnableFinalMenu
+            m_Mode: 1
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: 
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1776808646
 Prefab:
   m_ObjectHideFlags: 0
@@ -23277,6 +37383,112 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &1789897690
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1373479370052082, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1789897691}
+  - component: {fileID: 1789897693}
+  - component: {fileID: 1789897692}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1789897691
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4121335786700494, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1789897690}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.038322937, y: 0.6780029, z: -0.12146111}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 872341593}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1789897692
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23358306118417846, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1789897690}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1789897693
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33140305107604506, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1789897690}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1791992347
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000014270861712, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1791992348}
+  m_Layer: 0
+  m_Name: Ring
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1791992348
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012202363908, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1791992347}
+  m_LocalRotation: {x: 0.8380313, y: -0.026036365, z: -0.013264355, w: -0.5448392}
+  m_LocalPosition: {x: -0.20644368, y: 1.5600718, z: 1.1891656}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1799452395
 GameObject:
   m_ObjectHideFlags: 0
@@ -23541,6 +37753,197 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1806797254}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1806894473
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1800282708006164, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1806894474}
+  - component: {fileID: 1806894476}
+  - component: {fileID: 1806894475}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1806894474
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4456678432152938, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1806894473}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.001033567, y: 0.14278637, z: 0.091374226}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 114110166}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1806894475
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23281947714866160, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1806894473}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1806894476
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33406297391029328, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1806894473}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1809244139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1809244140}
+  - component: {fileID: 1809244142}
+  - component: {fileID: 1809244141}
+  m_Layer: 0
+  m_Name: Then pinch
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1809244140
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1809244139}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1809244141
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1809244139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76f3179ee3c21564a81795625cc0cabb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 939237214}
+  transitionState: {fileID: 0}
+  controller: {fileID: 1649983743}
+  markerName: PromptPinch
+  condition: 1
+--- !u!114 &1809244142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1809244139}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: SkipMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: PromptHand
+              m_BoolArgument: 0
+            m_CallState: 2
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: LoopAtMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: PromptPinch
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+--- !u!1 &1812142579
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1812142580}
+  m_Layer: 0
+  m_Name: '--------'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1812142580
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1812142579}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 27
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1812959097
 Prefab:
   m_ObjectHideFlags: 0
@@ -23607,6 +38010,80 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
   m_PrefabInternal: {fileID: 1812959097}
+--- !u!1 &1824284224
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1824284225}
+  - component: {fileID: 1824284227}
+  - component: {fileID: 1824284226}
+  m_Layer: 0
+  m_Name: Now do it (waiting)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1824284225
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1824284224}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1824284226
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1824284224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4735e94b9c74d3b4dac2321a2c985dc6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1465239053}
+  transitionState: {fileID: 0}
+  tutorialControl: {fileID: 1840705451}
+--- !u!114 &1824284227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1824284224}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: LoopAtMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: WaitForColor
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1 &1825888680
 GameObject:
   m_ObjectHideFlags: 0
@@ -23763,6 +38240,83 @@ Transform:
   m_Father: {fileID: 9705077}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1826535515
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1815596059091772, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1826535516}
+  - component: {fileID: 1826535518}
+  - component: {fileID: 1826535517}
+  m_Layer: 5
+  m_Name: Marble
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1826535516
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4626060280423356, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1826535515}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 892674014}
+  m_Father: {fileID: 1842645388}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1826535517
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23228594486138270, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1826535515}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 28eefa2b18c4cac49be691746e981da5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1826535518
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33482828046456164, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1826535515}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1826896471
 GameObject:
   m_ObjectHideFlags: 0
@@ -23971,6 +38525,172 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &1828041192
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1828041193}
+  - component: {fileID: 1828041195}
+  - component: {fileID: 1828041194}
+  m_Layer: 0
+  m_Name: Now we need more control
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1828041193
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828041192}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 25
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1828041194
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828041192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1706391412}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &1828041195
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828041192}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 4bdd32b218fd3a8449c0d79347336c10, type: 2}
+  _wrapMode: 2
+--- !u!1 &1830468853
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1424095760541154, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1830468854}
+  - component: {fileID: 1830468856}
+  - component: {fileID: 1830468855}
+  m_Layer: 0
+  m_Name: Color Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1830468854
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4093741952876570, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830468853}
+  m_LocalRotation: {x: -0.000000010536666, y: 1, z: -2.4123681e-14, w: 0.000000010536719}
+  m_LocalPosition: {x: 0.24022886, y: 0.5543475, z: 0.86336786}
+  m_LocalScale: {x: 2.585033, y: 2.5850334, z: 2.585033}
+  m_Children: []
+  m_Father: {fileID: 990536909}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1830468855
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23744785159792486, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830468853}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 661ce5ac1cb703c40bc05fe7e7d412e8, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1830468856
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33870617744827828, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1830468853}
+  m_Mesh: {fileID: 4300000, guid: b4f15e6e8137bb44b95d513250344c2f, type: 3}
+--- !u!1 &1832814774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1832814775}
+  m_Layer: 0
+  m_Name: Brush
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1832814775
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1832814774}
+  m_LocalRotation: {x: -0.08024353, y: 0.9259285, z: 0.3603441, w: 0.079809465}
+  m_LocalPosition: {x: -3.506846, y: 22.38671, z: 6.9248066}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 230986567}
+  - {fileID: 94550650}
+  - {fileID: 1529262421}
+  - {fileID: 150231449}
+  m_Father: {fileID: 1050640148}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1833997286
 GameObject:
   m_ObjectHideFlags: 0
@@ -24201,6 +38921,155 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &1840705450
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1840705453}
+  - component: {fileID: 1840705452}
+  - component: {fileID: 1840705451}
+  m_Layer: 0
+  m_Name: Tutorial Control
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1840705451
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1840705450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b4455fd4f96bb4944b2f571838c95768, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  text: {fileID: 1955089288}
+  rightPinch: {fileID: 757562291}
+  strokeParent: {fileID: 181722601}
+  colorWidget:
+    widget: {fileID: 146733977}
+    ring: {fileID: 1888140364}
+    emergables:
+    - {fileID: 113997874}
+    ieBehaviour: {fileID: 146733980}
+    trigger: {fileID: 1144605980}
+  brushWidget:
+    widget: {fileID: 2038811062}
+    ring: {fileID: 948901543}
+    emergables:
+    - {fileID: 931763937}
+    ieBehaviour: {fileID: 2038811065}
+    trigger: {fileID: 1045056474}
+  menuWidget:
+    widget: {fileID: 1255518558}
+    ring: {fileID: 2045431048}
+    emergables:
+    - {fileID: 1847961898}
+    - {fileID: 1914107080}
+    - {fileID: 1837468448}
+    ieBehaviour: {fileID: 1255518560}
+    trigger: {fileID: 1627801428}
+  bigColorEmergable: {fileID: 1105313102}
+  brushThicknessObject: {fileID: 793039320}
+--- !u!114 &1840705452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1840705450}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe37572ae69fd0a47b30b649bd407204, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enableManualTransition: 1
+  manualTransitionKey: 286
+--- !u!4 &1840705453
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1840705450}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 222778850}
+  - {fileID: 1581307253}
+  - {fileID: 441987438}
+  - {fileID: 1719081242}
+  - {fileID: 582206190}
+  - {fileID: 2135389034}
+  - {fileID: 346890190}
+  - {fileID: 960477182}
+  - {fileID: 1809244140}
+  - {fileID: 939237215}
+  - {fileID: 1962621080}
+  - {fileID: 72011315}
+  - {fileID: 176873342}
+  - {fileID: 1930824381}
+  - {fileID: 532545420}
+  - {fileID: 1824284225}
+  - {fileID: 1465239054}
+  - {fileID: 227293554}
+  - {fileID: 1158073987}
+  - {fileID: 269842664}
+  - {fileID: 225111329}
+  - {fileID: 640536047}
+  - {fileID: 1737902598}
+  - {fileID: 693536397}
+  - {fileID: 1567539284}
+  - {fileID: 1828041193}
+  - {fileID: 1706391413}
+  - {fileID: 1812142580}
+  - {fileID: 1541230324}
+  - {fileID: 789892010}
+  - {fileID: 1637684300}
+  - {fileID: 2022802838}
+  - {fileID: 1671806022}
+  - {fileID: 1774235340}
+  - {fileID: 1191593142}
+  m_Father: {fileID: 0}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1842645387
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1490407357767300, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1842645388}
+  m_Layer: 5
+  m_Name: Color Marble
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1842645388
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4463262986011326, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1842645387}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1826535516}
+  - {fileID: 2108548015}
+  m_Father: {fileID: 2010003633}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1843623183
 GameObject:
   m_ObjectHideFlags: 0
@@ -24474,6 +39343,317 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &1850431810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1183848857368550, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1850431811}
+  m_Layer: 5
+  m_Name: WearableUI Objects
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1850431811
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4006878253615278, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1850431810}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1939700508}
+  m_Father: {fileID: 2010003633}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1851737851
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1814187469512418, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1851737852}
+  m_Layer: 0
+  m_Name: Color Swatch (10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1851737852
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4940274049760896, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1851737851}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 2.5482693, y: 1.86, z: -0.71}
+  m_LocalScale: {x: 0.38720986, y: 0.38720933, z: 0.38720956}
+  m_Children:
+  - {fileID: 435959905}
+  - {fileID: 236630787}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1860839464
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1860839465}
+  - component: {fileID: 1860839467}
+  - component: {fileID: 1860839466}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1860839465
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1860839464}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.411, y: 0.457, z: 0.464}
+  m_LocalScale: {x: 0.24241668, y: 0.24241668, z: 0.24241668}
+  m_Children: []
+  m_Father: {fileID: 1555422911}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1860839466
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1860839464}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d2e7353916bd3c438be7c48258805b2, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1860839467
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1860839464}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!43 &1863712964
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Ribbon Circle Mesh
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 1536
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 256
+    localAABB:
+      m_Center: {x: 0.00000011920929, y: 0, z: -0.000000059604645}
+      m_Extent: {x: 1.1999999, y: 0.02, z: 1.1999998}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
+  m_Skin: []
+  m_VertexData:
+    serializedVersion: 2
+    m_VertexCount: 256
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 6144
+    _typelessdata: 9a99993f0ad7a33c000000008ef4e43d11657e3f1bf4efbacdcc4c3f0ad7a33c00000000bde6aebd82107f3ff750b7ba9a99993f0ad7a3bc000000008ff4e43d11657ebfebf7ef3acdcc4c3f0ad7a3bc00000000c0e6aebd83107fbf9d4cb73a41dc983f0ad7a33c0ee3f0bd3f7ce33d11657e3fce6151bc57d04b3f0ad7a33c5e97a0bd0457aebd83107f3f50b0e43b41dc983f0ad7a3bc0ee3f0bd6838e43d11657ebfe9ae15bc57d04b3f0ad7a3bc5e97a0bd48c7adbd83107fbf0bf31f3c0ca6963f0ad7a33c1cba6fbe12d3df3d0f657e3f9160c1bc65dd483f0ad7a33c68d11fbe7619acbd82107f3fff7f7a3c0ca6963f0ad7a3bc1cba6fbe9649e13d11657ebf76f5a3bc65dd483f0ad7a3bc68d11fbe5ffbaabd83107fbf09b9933c6cfc923f0ad7a33cd459b2be1e02da3d11657e3f9a190cbd3bfb433f0ad7a33c1bcd6dbe9a33a8bd81107f3f271fc03c6cfc923f0ad7a3bcd459b2be592fdc3d11657ebf727ffbbc3bfb433f0ad7a3bc1bcd6dbeed89a6bd82107fbf3d0cd63c6ce88d3f0ad7a33ce61eebbea517d23d11657e3f9d2936bde5353d3f0ad7a33c44bf9cbe11afa2bd83107f3f4c92003d6ce88d3f0ad7a3bce61eebbe41f6d43d11657ebf8a4e28bde5353d3f0ad7a3bc44bf9cbee37da0bd83107fbfef270b3d8e76873f0ad7a33c25d010bf3227c83d11657e3f84785ebd129e343f0ad7a33c8715c1be6f999bbd82107f3f16d81f3d8e76873f0ad7a3bc25d010bf1db0cb3d11657ebf9b3e51bd129e343f0ad7a3bc8715c1be2be698bd83107fbf9df2293d6e6d7f3f0ad7a33cd1ab2abf5249bc3d11657e3f755182bdf4482a3f0ad7a33cc28fe3be350493bd82107f3fbe933d3d6e6d7f3f0ad7a3bcd1ab2abfce73c03d11657ebfad2a78bdf4482a3f0ad7a3bcc28fe3be80d58fbd83107fbf581a473d04786d3f0ad7a33cb6e242bf3a9bae3d11657e3f5e2594bd02501e3f0ad7a33c7aec01bf800489bd83107f3f107c593d04786d3f0ad7a3bcb6e242bf055db33d11657ebf77598ebd02501e3f0ad7a3bc7aec01bf356285bd83107fbf2e57623d2439593f0ad7a33c223959bfa73e9f3d11657e3f0b8ca4bdc2d0103f0ad7a33cc2d010bffc657bbd82107f3f244c733d2439593f0ad7a3bc223959bf088ca43d11657ebfa53e9fbdc2d0103f0ad7a3bcc2d010bf224c73bd83107fbffa657b3db8e2423f0ad7a33c02786dbf7b598e3d11657e3f085db3bd7aec013f0ad7a33c02501ebf285762bd83107f3f3462853db8e2423f0ad7a3bc02786dbf6025943d11657ebf3b9baebd7aec013f0ad7a3bc02501ebf057c59bd82107fbf7d04893dd2ab2a3f0ad7a33c6d6d7fbfa92a783d11657e3fd073c0bdc38fe33e0ad7a33cf3482abf551a47bd83107f3f7ed58f3dd2ab2a3f0ad7a3bc6d6d7fbf7651823d11657ebf5349bcbdc38fe33e0ad7a3bcf3482abfc1933dbd83107fbf3104933d26d0103f0ad7a33c8d7687bf973e513d11657e3f1fb0cbbd8815c13e0ad7a33c129e34bfa2f229bd83107f3f2de6983d26d0103f0ad7a3bc8d7687bf80785e3d10657ebf3727c8bd8815c13e0ad7a3bc129e34bf13d81fbd82107fbf71999b3de71eeb3e0ad7a33c6be88dbfa04e283d11657e3f40f6d4bd45bf9c3e0ad7a33ce4353dbfe6270bbd83107f3fe57da03de71eeb3e0ad7a3bc6be88dbfa729363d11657ebfa417d2bd45bf9c3e0ad7a3bce4353dbf489200bd82107fbf12afa23dd759b23e0ad7a33c6cfc92bf617ffb3c11657e3f592fdcbd1ecd6d3e0ad7a33c3afb43bf3f0cd6bc83107f3fed89a63dd759b23e0ad7a3bc6cfc92bfa5190c3d11657ebf1b02dabd1ecd6d3e0ad7a3bc3afb43bf291fc0bc82107fbf9b33a83d21ba6f3e0ad7a33c0ba696bf8af5a33c11657e3f9649e1bd6bd11f3e0ad7a33c64dd48bf09b993bc83107f3f5ffbaa3d21ba6f3e0ad7a3bc0ba696bf7d60c13c0f657ebf14d3dfbd6bd11f3e0ad7a3bc64dd48bf02807abc83107fbf7619ac3d18e3f03d0ad7a33c41dc98bfc0ae153c11657e3f6638e4bd6697a03d0ad7a33c56d04bbf0af31fbc83107f3f47c7ad3d18e3f03d0ad7a3bc41dc98bff561513c11657ebf3e7ce3bd6697a03d0ad7a3bc56d04bbf51b0e4bb83107fbf0357ae3da5c9bc330ad7a33c999999bf1ef4efba11657e3f8ff4e4bd86b77b330ad7a33ccccc4cbf134eb7ba83107f3fc1e6ae3da5c9bc330ad7a3bc999999bf1ef4ef3a11657ebf8ff4e4bd86b77b330ad7a3bccccc4cbf114eb73a83107fbfc0e6ae3d00e3f0bd0ad7a33c41dc98bfa56151bc11657e3f3f7ce3bd5697a0bd0ad7a33c56d04bbf23b0e43b82107f3f0357ae3d00e3f0bd0ad7a3bc41dc98bf98ae15bc11657ebf6638e4bd5697a0bd0ad7a3bc56d04bbfdbf21f3c83107fbf47c7ad3d15ba6fbe0ad7a33c0ca696bf9160c1bc0f657e3f13d3dfbd63d11fbe0ad7a33c65dd48bfd07f7a3c82107f3f7519ac3d15ba6fbe0ad7a3bc0ca696bf76f5a3bc11657ebf9649e1bd63d11fbe0ad7a3bc65dd48bffdb8933c83107fbf5ffbaa3dd159b2be0ad7a33c6cfc92bf9b190cbd11657e3f1d02dabd16cd6dbe0ad7a33c3bfb43bf291fc03c82107f3f9d33a83dd159b2be0ad7a3bc6cfc92bf747ffbbc11657ebf5a2fdcbd16cd6dbe0ad7a3bc3bfb43bf3d0cd63c83107fbfee89a63de21eebbe0ad7a33c6ce88dbf9a2936bd11657e3fa517d2bd42bf9cbe0ad7a33ce5353dbf4a92003d82107f3f10afa23de21eebbe0ad7a3bc6ce88dbf8a4e28bd11657ebf41f6d4bd42bf9cbe0ad7a3bce5353dbfef270b3d82107fbfe47da03d24d010bf0ad7a33c8e7687bf82785ebd11657e3f3427c8bd8515c1be0ad7a33c129e34bf16d81f3d82107f3f6f999b3d24d010bf0ad7a3bc8e7687bf983e51bd11657ebf1fb0cbbd8515c1be0ad7a3bc129e34bf99f2293d82107fbf28e6983dd0ab2abf0ad7a33c6e6d7fbf755182bd11657e3f5249bcbdc08fe3be0ad7a33cf4482abfbe933d3d82107f3f3504933dd0ab2abf0ad7a3bc6e6d7fbfad2a78bd11657ebfce73c0bdc08fe3be0ad7a3bcf4482abf581a473d83107fbf80d58f3db5e242bf0ad7a33c04786dbf5e2594bd11657e3f3a9baebd79ec01bf0ad7a33c02501ebf107c593d83107f3f8004893db5e242bf0ad7a3bc04786dbf77598ebd11657ebf055db3bd79ec01bf0ad7a3bc02501ebf2e57623d83107fbf3562853d213959bf0ad7a33c243959bf0b8ca4bd11657e3fa73e9fbdc1d010bf0ad7a33cc2d010bf244c733d82107f3ffc657b3d213959bf0ad7a3bc243959bfa53e9fbd11657ebf088ca4bdc1d010bf0ad7a3bcc2d010bffa657b3d83107fbf224c733d01786dbf0ad7a33cb8e242bf085db3bd11657e3f7b598ebd01501ebf0ad7a33c7aec01bf3462853d83107f3f2857623d01786dbf0ad7a3bcb8e242bf3b9baebd11657ebf602594bd01501ebf0ad7a3bc7aec01bf7d04893d82107fbf057c593d6c6d7fbf0ad7a33cd2ab2abfce73c0bd11657e3fb42a78bdf2482abf0ad7a33cc38fe3be7dd58f3d84107f3f561a473d6c6d7fbf0ad7a3bcd2ab2abf5249bcbd11657ebf795182bdf2482abf0ad7a3bcc38fe3be2d04933d82107fbfc1933d3d8d7687bf0ad7a33c27d010bf1fb0cbbd11657e3f883e51bd119e34bf0ad7a33c8915c1be29e6983d82107f3fa3f2293d8d7687bf0ad7a3bc27d010bf3527c8bd10657ebf81785ebd119e34bf0ad7a3bc8915c1be71999b3d83107fbf14d81f3d6ae88dbf0ad7a33ce81eebbe43f6d4bd10657e3f974e28bde3353dbf0ad7a33c46bf9cbee67da03d84107f3fed270b3d6ae88dbf0ad7a3bce81eebbea817d2bd10657ebf942936bde3353dbf0ad7a3bc46bf9cbe12afa23d82107fbf5492003d6bfc92bf0ad7a33cd859b2be5a2fdcbd10657e3f627ffbbc3afb43bf0ad7a33c20cd6dbef089a63d84107f3f500cd63c6bfc92bf0ad7a3bcd859b2be1d02dabd10657ebfa6190cbd3afb43bf0ad7a3bc20cd6dbe9e33a83d82107fbf201fc03c0aa696bf0ad7a33c23ba6fbe9949e1bd10657e3f8ef5a3bc63dd48bf0ad7a33c6dd11fbe61fbaa3d82107f3f00b9933c0aa696bf0ad7a3bc23ba6fbe16d3dfbd0f657ebf8060c1bc63dd48bf0ad7a3bc6dd11fbe7819ac3d83107fbf1c807a3c40dc98bf0ad7a33c1ee3f0bd6938e4bd11657e3fc3ae15bc56d04bbf0ad7a33c6a97a0bd4ac7ad3d83107f3f25f31f3c40dc98bf0ad7a3bc1ee3f0bd417ce3bd11657ebffa6151bc56d04bbf0ad7a3bc6a97a0bd0457ae3d82107fbf25b0e43b989999bf0ad7a33cbfb015b492f4e4bd10657e3f22f4ef3acbcc4cbf0ad7a33c5496c7b3c2e6ae3d82107f3f5a4db73a989999bf0ad7a3bcbfb015b491f4e4bd11657ebf22f4efbacbcc4cbf0ad7a3bc5496c7b3c2e6ae3d82107fbf5a4db7ba40dc98bf0ad7a33cf9e2f03d437ce3bd10657e3fa961513c56d04bbf0ad7a33c5197a03d0657ae3d83107f3ff8afe4bb40dc98bf0ad7a3bcf9e2f03d6a38e4bd11657ebf9aae153c56d04bbf0ad7a3bc5197a03d4ac7ad3d82107fbff6f21fbc0ba696bf0ad7a33c11ba6f3e18d3dfbd0f657e3f6d60c13c64dd48bf0ad7a33c61d11f3e7619ac3d83107f3fff7f7abc0ba696bf0ad7a3bc11ba6f3e9849e1bd11657ebf63f5a33c64dd48bf0ad7a3bc61d11f3e61fbaa3d82107fbf0ab993bc6cfc92bf0ad7a33cd059b23e1a02dabd11657e3fa4190c3d3afb43bf0ad7a33c15cd6d3e9d33a83d82107f3f2a1fc0bc6cfc92bf0ad7a3bcd059b23e5b2fdcbd11657ebf607ffb3c3afb43bf0ad7a3bc15cd6d3eec89a63d83107fbf3f0cd6bc6be88dbf0ad7a33ce01eeb3ea317d2bd10657e3fa929363de4353dbf0ad7a33c40bf9c3e12afa23d84107f3f4a9200bd6be88dbf0ad7a3bce01eeb3e40f6d4bd10657ebfa14e283de4353dbf0ad7a3bc40bf9c3ee57da03d84107fbfe7270bbd8d7687bf0ad7a33c22d0103f3a27c8bd11657e3f7f785e3d129e34bf0ad7a33c8315c13e70999b3d82107f3f11d81fbd8d7687bf0ad7a3bc22d0103f1eb0cbbd11657ebf953e513d129e34bf0ad7a3bc8315c13e2ce6983d82107fbfa3f229bd6d6d7fbf0ad7a33ccfab2a3f5149bcbd11657e3f7651823df3482abf0ad7a33cbe8fe33e3404933d82107f3fc2933dbd6d6d7fbf0ad7a3bccfab2a3fd373c0bd11657ebfab2a783df3482abf0ad7a3bcbe8fe33e80d58f3d83107fbf521a47bd02786dbf0ad7a33cb4e2423f3b9baebd10657e3f6125943d02501ebf0ad7a33c78ec013f8304893d84107f3f097c59bd02786dbf0ad7a3bcb4e2423f075db3bd10657ebf7d598e3d02501ebf0ad7a3bc78ec013f3862853d84107fbf2d5762bd223959bf0ad7a33c2039593fa73e9fbd11657e3f0b8ca43dc2d010bf0ad7a33cc0d0103fff657b3d83107f3f274c73bd223959bf0ad7a3bc2039593f0b8ca4bd11657ebfa73e9f3dc2d010bf0ad7a3bcc0d0103f274c733d83107fbfff657bbdb6e242bf0ad7a33c00786d3f79598ebd10657e3f085db33d7aec01bf0ad7a33c00501e3f3257623d84107f3f376285bdb6e242bf0ad7a3bc00786d3f5e2594bd10657ebf3b9bae3d7aec01bf0ad7a3bc00501e3f107c593d82107fbf800489bdd1ab2abf0ad7a33c6a6d7f3fb12a78bd10657e3fd073c03dc28fe3be0ad7a33cf2482a3f591a473d82107f3f81d58fbdd1ab2abf0ad7a3bc6a6d7f3f765182bd10657ebf5349bc3dc28fe3be0ad7a3bcf2482a3fc1933d3d83107fbf370493bd25d010bf0ad7a33c8c76873f9c3e51bd10657e3f1eb0cb3d8715c1be0ad7a33c109e343f9af2293d84107f3f30e698bd25d010bf0ad7a3bc8c76873f8a785ebd10657ebf3627c83d8715c1be0ad7a3bc109e343f0fd81f3d84107fbf73999bbde61eebbe0ad7a33c6ae88d3fa14e28bd10657e3f40f6d43d44bf9cbe0ad7a33ce2353d3fec270b3d83107f3fe47da0bde61eebbe0ad7a3bc6ae88d3fa72936bd11657ebfa217d23d44bf9cbe0ad7a3bce2353d3f5492003d82107fbf10afa2bdd659b2be0ad7a33c6bfc923f617ffbbc11657e3f5b2fdc3d1dcd6dbe0ad7a33c39fb433f4b0cd63c82107f3feb89a6bdd659b2be0ad7a3bc6bfc923fa5190cbd11657ebf1c02da3d1dcd6dbe0ad7a3bc39fb433f201fc03c82107fbf9d33a8bd1eba6fbe0ad7a33c0aa6963f8df5a3bc11657e3f9849e13d6ad11fbe0ad7a33c62dd483ffeb8933c83107f3f60fbaabd1eba6fbe0ad7a3bc0aa6963f7f60c1bc0f657ebf14d3df3d6ad11fbe0ad7a3bc62dd483f18807a3c83107fbf7619acbd16e3f0bd0ad7a33c40dc983fc3ae15bc11657e3f6838e43d6497a0bd0ad7a33c55d04b3f23f31f3c82107f3f48c7adbd16e3f0bd0ad7a3bc40dc983ffa6151bc11657ebf3f7ce33d6497a0bd0ad7a3bc55d04b3f25b0e43b82107fbf0457aebdf6aeb4b30ad7a33c9899993f22f4ef3a11657e3f91f4e43d48e970b30ad7a33ccacc4c3f584db73a82107f3fc0e6aebdf6aeb4b30ad7a3bc9899993f22f4efba11657ebf91f4e43d48e970b30ad7a3bccacc4c3f584db7ba82107fbfc0e6aebdffe2f03d0ad7a33c40dc983ff861513c11657e3f3e7ce33d5597a03d0ad7a33c55d04b3ff6afe4bb82107f3f0557aebdffe2f03d0ad7a3bc40dc983fc3ae153c11657ebf6838e43d5597a03d0ad7a3bc55d04b3ff6f21fbc82107fbf48c7adbd14ba6f3e0ad7a33c0aa6963f8060c13c0f657e3f17d3df3d62d11f3e0ad7a33c63dd483fec7f7abc83107f3f7819acbd14ba6f3e0ad7a3bc0aa6963f8df5a33c11657ebf9949e13d62d11f3e0ad7a3bc63dd483ff3b893bc82107fbf61fbaabdd159b23e0ad7a33c6bfc923fa5190c3d10657e3f1c02da3d16cd6d3e0ad7a33c3afb433f1f1fc0bc82107f3f9e33a8bdd159b23e0ad7a3bc6bfc923f637ffb3c10657ebf5d2fdc3d16cd6d3e0ad7a3bc3afb433f4d0cd6bc83107fbff089a6bde11eeb3e0ad7a33c6ae88d3f9729363d10657e3fa717d23d41bf9c3e0ad7a33ce3353d3f569200bd84107f3f13afa2bde11eeb3e0ad7a3bc6ae88d3f984e283d10657ebf43f6d43d41bf9c3e0ad7a3bce3353d3fee270bbd83107fbfe77da0bd23d0103f0ad7a33c8d76873f80785e3d10657e3f3927c83d8415c13e0ad7a33c119e343f14d81fbd83107f3f71999bbd23d0103f0ad7a3bc8d76873f883e513d11657ebf1fb0cb3d8415c13e0ad7a3bc119e343fa6f229bd83107fbf2de698bdcfab2a3f0ad7a33c6c6d7f3f7951823d11657e3f5049bc3dbe8fe33e0ad7a33cf2482a3fc5933dbd83107f3f330493bdcfab2a3f0ad7a3bc6c6d7f3fb52a783d11657ebfd073c03dbe8fe33e0ad7a3bcf2482a3f531a47bd82107fbf7ed58fbdb4e2423f0ad7a33c01786d3f6125943d10657e3f3b9bae3d78ec013f0ad7a33c01501e3f097c59bd84107f3f830489bdb4e2423f0ad7a3bc01786d3f7d598e3d10657ebf075db33d78ec013f0ad7a3bc01501e3f2d5762bd84107fbf386285bd2039593f0ad7a33c2139593f0b8ca43d11657e3fa73e9f3dc0d0103f0ad7a33cc1d0103f274c73bd83107f3fff657bbd2039593f0ad7a3bc2139593fa73e9f3d11657ebf0b8ca43dc0d0103f0ad7a3bcc1d0103fff657bbd83107fbf274c73bd00786d3f0ad7a33cb5e2423f085db33d10657e3f79598e3d00501e3f0ad7a33c79ec013f376285bd84107f3f325762bd00786d3f0ad7a3bcb5e2423f3b9bae3d10657ebf5e25943d00501e3f0ad7a3bc79ec013f800489bd82107fbf107c59bd6a6d7f3f0ad7a33cd0ab2a3fd073c03d10657e3fb12a783df2482a3f0ad7a33cc08fe33e80d58fbd84107f3f5c1a47bd6a6d7f3f0ad7a3bcd0ab2a3f5349bc3d10657ebf7651823df2482a3f0ad7a3bcc08fe33e350493bd83107fbfc2933dbd8c76873f0ad7a33c24d0103f20b0cb3d10657e3f9e3e513d109e343f0ad7a33c8615c13e2de698bd84107f3f9af229bd8c76873f0ad7a3bc24d0103f3527c83d11657ebf89785e3d109e343f0ad7a3bc8615c13e74999bbd84107fbf0fd81fbd6ae88d3f0ad7a33ce41eeb3e41f6d43d11657e3fa04e283de2353d3f0ad7a33c42bf9c3ee47da0bd83107f3fea270bbd6ae88d3f0ad7a3bce41eeb3ea317d23d11657ebfa729363de2353d3f0ad7a3bc42bf9c3e11afa2bd82107fbf549200bd6bfc923f0ad7a33cd359b23e592fdc3d11657e3f617ffb3c39fb433f0ad7a33c1acd6d3eec89a6bd82107f3f4d0cd6bc6bfc923f0ad7a3bcd359b23e1c02da3d11657ebfa5190c3d39fb433f0ad7a3bc1acd6d3e9b33a8bd82107fbf1d1fc0bc0aa6963f0ad7a33c1aba6f3e9749e13d11657e3f8cf5a33c62dd483f0ad7a33c66d11f3e60fbaabd83107f3ffeb893bc0aa6963f0ad7a3bc1aba6f3e15d3df3d0f657ebf8060c13c62dd483f0ad7a3bc66d11f3e7619acbd82107fbf1a807abc40dc983f0ad7a33c0ce3f03d6838e43d11657e3f64af153c55d04b3f0ad7a33c5e97a03d46c7adbd82107f3f67f31fbc40dc983f0ad7a3bc0ce3f03d3d7ce33d11657ebf4762513c55d04b3f0ad7a3bc5e97a03d0457aebd83107fbf3cb1e4bb
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.00000011920929, y: 0, z: -0.000000059604645}
+    m_Extent: {x: 1.1999999, y: 0.02, z: 1.1999998}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
+--- !u!1 &1864714346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1864714347}
+  m_Layer: 0
+  m_Name: PinkyKnuckle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1864714347
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1864714346}
+  m_LocalRotation: {x: 0.8574678, y: 0.008783347, z: 0.08120872, w: -0.50801295}
+  m_LocalPosition: {x: -0.18771777, y: 1.478569, z: 1.2251265}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1134568025}
+  - {fileID: 1373595205}
+  m_Father: {fileID: 206834523}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1888140364
 GameObject:
   m_ObjectHideFlags: 0
@@ -24731,6 +39911,35 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!1 &1889300876
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 100000, guid: 0a969de86108bb448bd93c6901920346, type: 3}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1889300877}
+  m_Layer: 0
+  m_Name: Icon
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1889300877
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 400000, guid: 0a969de86108bb448bd93c6901920346, type: 3}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1889300876}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 0.5}
+  m_Children:
+  - {fileID: 147188498}
+  m_Father: {fileID: 1289417879}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1890826358
 GameObject:
   m_ObjectHideFlags: 0
@@ -24952,6 +40161,228 @@ MonoBehaviour:
   _selectorPrefab: {fileID: 224000011509674004, guid: d107f9ddf1e2ea647bceef8c3bdd6880,
     type: 2}
   noFilesFoundText: {fileID: 673997414}
+--- !u!1 &1908323253
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1550813811857186, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1908323254}
+  - component: {fileID: 1908323256}
+  - component: {fileID: 1908323255}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1908323254
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4774583330976634, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1908323253}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.1788927, y: -0.1695192, z: 0.13473515}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 158968539}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1908323255
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23749991293142630, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1908323253}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1908323256
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33661983493859744, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1908323253}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!43 &1912623243
+Mesh:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Ribbon Circle Mesh
+  serializedVersion: 8
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 1536
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 256
+    localAABB:
+      m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
+      m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100fd0000000400010001000300ff0001000500030003000200fe000200030007000000fc000200000002000600040005000100040008000500050007000300050009000700070006000200060007000b00040000000600040006000a0008000900050008000c00090009000b00070009000d000b000b000a0006000a000b000f00080004000a0008000a000e000c000d0009000c0010000d000d000f000b000d0011000f000f000e000a000e000f0013000c0008000e000c000e001200100011000d00100014001100110013000f00110015001300130012000e0012001300170010000c001200100012001600140015001100140018001500150017001300150019001700170016001200160017001b00140010001600140016001a0018001900150018001c00190019001b00170019001d001b001b001a0016001a001b001f00180014001a0018001a001e001c001d0019001c0020001d001d001f001b001d0021001f001f001e001a001e001f0023001c0018001e001c001e002200200021001d00200024002100210023001f00210025002300230022001e0022002300270020001c002200200022002600240025002100240028002500250027002300250029002700270026002200260027002b00240020002600240026002a0028002900250028002c00290029002b00270029002d002b002b002a0026002a002b002f00280024002a0028002a002e002c002d0029002c0030002d002d002f002b002d0031002f002f002e002a002e002f0033002c0028002e002c002e003200300031002d00300034003100310033002f00310035003300330032002e0032003300370030002c003200300032003600340035003100340038003500350037003300350039003700370036003200360037003b00340030003600340036003a0038003900350038003c00390039003b00370039003d003b003b003a0036003a003b003f00380034003a0038003a003e003c003d0039003c0040003d003d003f003b003d0041003f003f003e003a003e003f0043003c0038003e003c003e004200400041003d00400044004100410043003f00410045004300430042003e0042004300470040003c004200400042004600440045004100440048004500450047004300450049004700470046004200460047004b00440040004600440046004a0048004900450048004c00490049004b00470049004d004b004b004a0046004a004b004f00480044004a0048004a004e004c004d0049004c0050004d004d004f004b004d0051004f004f004e004a004e004f0053004c0048004e004c004e005200500051004d00500054005100510053004f00510055005300530052004e0052005300570050004c005200500052005600540055005100540058005500550057005300550059005700570056005200560057005b00540050005600540056005a0058005900550058005c00590059005b00570059005d005b005b005a0056005a005b005f00580054005a0058005a005e005c005d0059005c0060005d005d005f005b005d0061005f005f005e005a005e005f0063005c0058005e005c005e006200600061005d00600064006100610063005f00610065006300630062005e0062006300670060005c006200600062006600640065006100640068006500650067006300650069006700670066006200660067006b00640060006600640066006a0068006900650068006c00690069006b00670069006d006b006b006a0066006a006b006f00680064006a0068006a006e006c006d0069006c0070006d006d006f006b006d0071006f006f006e006a006e006f0073006c0068006e006c006e007200700071006d00700074007100710073006f00710075007300730072006e0072007300770070006c007200700072007600740075007100740078007500750077007300750079007700770076007200760077007b00740070007600740076007a0078007900750078007c00790079007b00770079007d007b007b007a0076007a007b007f00780074007a0078007a007e007c007d0079007c0080007d007d007f007b007d0081007f007f007e007a007e007f0083007c0078007e007c007e008200800081007d00800084008100810083007f00810085008300830082007e0082008300870080007c008200800082008600840085008100840088008500850087008300850089008700870086008200860087008b00840080008600840086008a0088008900850088008c00890089008b00870089008d008b008b008a0086008a008b008f00880084008a0088008a008e008c008d0089008c0090008d008d008f008b008d0091008f008f008e008a008e008f0093008c0088008e008c008e009200900091008d00900094009100910093008f00910095009300930092008e0092009300970090008c009200900092009600940095009100940098009500950097009300950099009700970096009200960097009b00940090009600940096009a0098009900950098009c00990099009b00970099009d009b009b009a0096009a009b009f00980094009a0098009a009e009c009d0099009c00a0009d009d009f009b009d00a1009f009f009e009a009e009f00a3009c0098009e009c009e00a200a000a1009d00a000a400a100a100a3009f00a100a500a300a300a2009e00a200a300a700a0009c00a200a000a200a600a400a500a100a400a800a500a500a700a300a500a900a700a700a600a200a600a700ab00a400a000a600a400a600aa00a800a900a500a800ac00a900a900ab00a700a900ad00ab00ab00aa00a600aa00ab00af00a800a400aa00a800aa00ae00ac00ad00a900ac00b000ad00ad00af00ab00ad00b100af00af00ae00aa00ae00af00b300ac00a800ae00ac00ae00b200b000b100ad00b000b400b100b100b300af00b100b500b300b300b200ae00b200b300b700b000ac00b200b000b200b600b400b500b100b400b800b500b500b700b300b500b900b700b700b600b200b600b700bb00b400b000b600b400b600ba00b800b900b500b800bc00b900b900bb00b700b900bd00bb00bb00ba00b600ba00bb00bf00b800b400ba00b800ba00be00bc00bd00b900bc00c000bd00bd00bf00bb00bd00c100bf00bf00be00ba00be00bf00c300bc00b800be00bc00be00c200c000c100bd00c000c400c100c100c300bf00c100c500c300c300c200be00c200c300c700c000bc00c200c000c200c600c400c500c100c400c800c500c500c700c300c500c900c700c700c600c200c600c700cb00c400c000c600c400c600ca00c800c900c500c800cc00c900c900cb00c700c900cd00cb00cb00ca00c600ca00cb00cf00c800c400ca00c800ca00ce00cc00cd00c900cc00d000cd00cd00cf00cb00cd00d100cf00cf00ce00ca00ce00cf00d300cc00c800ce00cc00ce00d200d000d100cd00d000d400d100d100d300cf00d100d500d300d300d200ce00d200d300d700d000cc00d200d000d200d600d400d500d100d400d800d500d500d700d300d500d900d700d700d600d200d600d700db00d400d000d600d400d600da00d800d900d500d800dc00d900d900db00d700d900dd00db00db00da00d600da00db00df00d800d400da00d800da00de00dc00dd00d900dc00e000dd00dd00df00db00dd00e100df00df00de00da00de00df00e300dc00d800de00dc00de00e200e000e100dd00e000e400e100e100e300df00e100e500e300e300e200de00e200e300e700e000dc00e200e000e200e600e400e500e100e400e800e500e500e700e300e500e900e700e700e600e200e600e700eb00e400e000e600e400e600ea00e800e900e500e800ec00e900e900eb00e700e900ed00eb00eb00ea00e600ea00eb00ef00e800e400ea00e800ea00ee00ec00ed00e900ec00f000ed00ed00ef00eb00ed00f100ef00ef00ee00ea00ee00ef00f300ec00e800ee00ec00ee00f200f000f100ed00f000f400f100f100f300ef00f100f500f300f300f200ee00f200f300f700f000ec00f200f000f200f600f400f500f100f400f800f500f500f700f300f500f900f700f700f600f200f600f700fb00f400f000f600f400f600fa00f800f900f500f800fc00f900f900fb00f700f900fd00fb00fb00fa00f600fa00fb00ff00f800f400fa00f800fa00fe00fc00fd00f900fc000000fd00fd00ff00fb00fd000100ff00ff00fe00fa00fe00ff000300fc00f800fe00fc00fe000200
+  m_Skin: []
+  m_VertexData:
+    serializedVersion: 2
+    m_VertexCount: 256
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 6144
+    _typelessdata: d9cef73c6f12833900000000a681353fa881343f67393ebc45b6f33c6f128339000000003e8034bf1e83353f822e3dbcd9cef73c6f1283b900000000a681353fa88134bf233d3e3c45b6f33c6f1283b9000000003e8034bf1e8335bfbb2a3d3c5e9df63c6f128339c15042bb5d57343f9c81343f59fda5bdd889f23c6f128339871a3fbbf2eb33bf1383353f8d026c3d5e9df63c6f1283b9c15042bb87ec343f9c8134bf5c536dbdd889f23c6f1283b9871a3fbb9b5733bf148335bf0912a53de30bf33c6f1283393861c1bb6270313fa581343f2a4d19be7507ef3c6f128339f42ebebbfb9b31bf1e83353f8c42013ee30bf33c6f1283b93861c1bb4699323fa58134bfd2fa01be7507ef3c6f1283b9f42ebebbbf7430bf1e8335bfb973183e3023ed3c6f128339a6de0fbc02d42c3f9e81343fa2215ebec437e93c6f128339e07d0dbc39962dbf1683353fc745463e3023ed3c6f1283b9a6de0fbcc48d2e3f9c8134bf956047bec437e93c6f1283b9e07d0dbce9de2bbf188335bf9de65c3edaf1e43c6f128339fea93dbc7e8d263fa281343f476990be1829e13c6f12833972873abc71e427bf1983353f17b0843edaf1e43c6f1283b9fea93dbcded3283fa08134bf4f6d85be1829e13c6f1283b972873abc49a125bf198335bf759c8f3e108cda3c6f128339bba169bc64ac1e3f9d81343fa95db0be4eefd63c6f12833923c565bcc89420bf1083353f37f6a43e108cda3c6f1283b9bba169bcc579213f988134bf79e1a5be4eefd63c6f1283b923c565bc5dcb1dbf158335bf8c63af3e790bce3c6f128339bbac89bc1544153f9b81343f3d9fcebe9da3ca3c6f1283392d6687bc24b917bf1d83353f86a5c33e790bce3c6f1283b9bbac89bc8591183fa78134bf84bcc4be9da3ca3c6f1283b92d6687bc647014bf128335bf427acd3ee48ebf3c6f1283392d359dbcb06b0a3fac81343f5ee3eabe5464bc3c6f128339f79b9abc7a670dbf2183353f8d72e03ee48ebf3c6f1283b92d359dbc22310e3fa88134bfa0b2e1be5464bc3c6f1283b9f79b9abc65a709bf268335bf3a96e93e093aaf3c6f128339083aafbc567cfc3e9f81343f3b7202bf9554ac3c6f1283399454acbc3eb901bf1783353f3e16fb3e093aaf3c6f1283b9083aafbc3b72023f9f8134bf567cfcbe9554ac3c6f1283b99454acbc3d16fbbe178335bf3eb9013f2e359d3c6f128339e38ebfbca0b2e13ea981343f23310ebff89b9a3c6f1283395364bcbc3a96e9be2683353f64a7093f2e359d3c6f1283b9e38ebfbc5ee3ea3eac8134bfb06b0abff89b9a3c6f1283b95364bcbc8d72e0be218335bf7a670d3fbcac893c6f128339780bcebc80bcc43ea581343f859118bf2e66873c6f1283399ca3cabc3f7acdbe1283353f6470143fbcac893c6f1283b9780bcebc3b9fce3e9b8134bf144415bf2e66873c6f1283b99ca3cabc86a5c3be1d8335bf27b9173fbca1693c6f1283390f8cdabc78e1a53e9a81343fc67921bf24c5653c6f1283394defd6bc8963afbe1483353f5ecb1d3fbca1693c6f1283b90f8cdabca75db03e9c8134bf64ac1ebf24c5653c6f1283b94defd6bc36f6a4be108335bfc794203fffa93d3c6f128339d9f1e4bc506d853ea081343fddd328bf73873a3c6f1283391729e1bc769c8fbe1983353f49a1253fffa93d3c6f1283b9d9f1e4bc4869903ea18134bf7d8d26bf73873a3c6f1283b91729e1bc18b084be198335bf70e4273fa8de0f3c6f1283392f23edbc9760473e9c81343fc58d2ebfe27d0d3c6f128339c337e9bc9ee65cbe1883353fe6de2b3fa8de0f3c6f1283b92f23edbca2215e3e9e8134bf01d42cbfe27d0d3c6f1283b9c337e9bcc94546be158335bf39962d3f3c61c13b6f128339e20bf3bce6fa013ea581343f459932bff82ebe3b6f1283397407efbcc27318be1d83353fbe74303f3c61c13b6f1283b9e20bf3bc344d193ea58134bf627031bff82ebe3b6f1283b97407efbca04201be1e8335bffb9b313fca50423b6f1283395e9df6bc34536d3d9b81343f87ec34bf901a3f3b6f128339d889f2bc1e12a5bd1483353f9b57333fca50423b6f1283b95e9df6bc6cfda53d9c8134bf5c5734bf901a3f3b6f1283b9d889f2bc64026cbd138335bff2eb333fea4918316f128339d8cef7bc073a3ebca781343fa68135bf84c515316f12833944b6f3bc5d2b3dbc1e83353f3e80343fea4918316f1283b9d8cef7bc073a3e3ca88134bfa68135bf84c515316f1283b944b6f3bc5d2b3d3c1e8335bf3e80343fb75042bb6f1283395e9df6bc46fda5bd9c81343f5d5734bf7d1a3fbb6f128339d889f2bc40026c3d1283353ff3eb333fb75042bb6f1283b95e9df6bc0d536dbd9b8134bf88ec34bf7d1a3fbb6f1283b9d889f2bcf811a53d168335bf9c57333f3261c1bb6f128339e30bf3bc2b4d19bea581343f627031bfee2ebebb6f1283397507efbc8c42013e1e83353ffb9b313f3261c1bb6f1283b9e30bf3bcd3fa01bea68134bf459932bfee2ebebb6f1283b97507efbcb973183e1d8335bfbe74303fa3de0fbc6f1283393023edbca2215ebe9e81343f02d42cbfdd7d0dbc6f128339c437e9bcc745463e1683353f39962d3fa3de0fbc6f1283b93023edbc956047be9c8134bfc48d2ebfdd7d0dbc6f1283b9c437e9bc9de65c3e188335bfe9de2b3ffba93dbc6f128339daf1e4bc476990bea281343f7e8d26bf6f873abc6f1283391829e1bc17b0843e1983353f71e4273ffba93dbc6f1283b9daf1e4bc4f6d85bea08134bfded328bf6f873abc6f1283b91829e1bc759c8f3e198335bf49a1253fb8a169bc6f128339108cdabca75db0be9c81343f64ac1ebf20c565bc6f1283394eefd6bc36f6a43e1083353fc794203fb8a169bc6f1283b9108cdabc78e1a5be9a8134bfc67921bf20c565bc6f1283b94eefd6bc8b63af3e148335bf5ecb1d3fbaac89bc6f128339790bcebc3c9fcebe9b81343f154415bf2c6687bc6f1283399da3cabc85a5c33e1d83353f26b9173fbaac89bc6f1283b9790bcebc80bcc4bea68134bf859118bf2c6687bc6f1283b99da3cabc3f7acd3e128335bf6470143f2c359dbc6f128339e48ebfbc5be3eabeac81343fb36b0abff69b9abc6f1283395464bcbc8972e03e2283353f79670d3f2c359dbc6f1283b9e48ebfbc9db2e1bea98134bf23310ebff69b9abc6f1283b95464bcbc3696e93e258335bf67a7093f083aafbc6f128339093aafbc3b7202bfa181343f517cfcbe9454acbc6f1283399554acbc3e16fb3e1683353f40b9013f083aafbc6f1283b9093aafbc567cfcbe9c8134bf3e7202bf9454acbc6f1283b99554acbc3eb9013f1a8335bf3816fb3ee28ebfbc6f1283392e359dbc25310ebfa881343f9eb2e1be5264bcbc6f128339f89b9abc66a7093f2783353f3396e93ee28ebfbc6f1283b92e359dbcb36b0abfaf8134bf59e3eabe5264bcbc6f1283b9f89b9abc7b670d3f1f8335bf8a72e03e770bcebc6f128339bcac89bc859118bfa781343f84bcc4be9ba3cabc6f1283392e6687bc6470143f1283353f427acd3e770bcebc6f1283b9bcac89bc154415bf9b8134bf3d9fcebe9ba3cabc6f1283b92e6687bc24b9173f1d8335bf86a5c33e0e8cdabc6f128339bda169bcc57921bf9881343f79e1a5be4cefd6bc6f12833925c565bc5dcb1d3f1583353f8b63af3e0e8cdabc6f1283b9bda169bc64ac1ebf9d8134bfa95db0be4cefd6bc6f1283b925c565bcc794203f108335bf37f6a43ed8f1e4bc6f12833900aa3dbcded328bfa181343f516d85be1629e1bc6f12833974873abc4aa1253f1a83353f779c8f3ed8f1e4bc6f1283b900aa3dbc7d8d26bfa18134bf486990be1629e1bc6f1283b974873abc70e4273f198335bf18b0843e2e23edbc6f128339a9de0fbcc58d2ebf9c81343f976047bec237e9bc6f128339e37d0dbce7de2b3f1983353f9fe65c3e2e23edbc6f1283b9a9de0fbc01d42cbf9e8134bfa2215ebec237e9bc6f1283b9e37d0dbc38962d3f148335bfc745463ee10bf3bc6f1283393e61c1bb459932bfa681343fe7fa01be7307efbc6f128339fa2ebebbbe74303f1d83353fc373183ee10bf3bc6f1283b93e61c1bb627031bfa58134bf354d19be7307efbc6f1283b9fa2ebebbfa9b313f1e8335bfa042013e5d9df6bc6f128339cf5042bb88ec34bf9b81343f35536dbdd789f2bc6f128339951a3fbb9b57333f1583353f1f12a53d5d9df6bc6f1283b9cf5042bb5c5734bf9c8134bf6dfda5bdd789f2bc6f1283b9951a3fbbf3eb333f148335bf67026c3dd7cef7bc6f128339228071b1a68135bfa781343f073a3e3c43b6f3bc6f12833940826db13e80343f1f83353f5e2b3d3cd7cef7bc6f1283b9228071b1a68135bfa78134bf073a3ebc43b6f3bc6f1283b940826db13e80343f1f8335bf5e2b3dbc5d9df6bc6f128339b150423b5c5734bf9c81343f46fda53dd789f2bc6f128339771a3f3bf3eb333f1283353f40026cbd5d9df6bc6f1283b9b150423b88ec34bf9b8134bf0d536d3dd789f2bc6f1283b9771a3f3b9b57333f158335bff611a5bde20bf3bc6f1283392f61c13b637031bfa481343f2a4d193e7407efbc6f128339eb2ebe3bfb9b313f1e83353f8c4201bee20bf3bc6f1283b92f61c13b469932bfa68134bfd3fa013e7407efbc6f1283b9eb2ebe3bbf74303f1e8335bfb97318be2f23edbc6f128339a2de0f3c01d42cbf9e81343fa2215e3ec337e9bc6f128339dc7d0d3c39962d3f1583353fc74546be2f23edbc6f1283b9a2de0f3cc58d2ebf9b8134bf9560473ec337e9bc6f1283b9dc7d0d3ce7de2b3f198335bf9ee65cbed9f1e4bc6f128339f9a93d3c7d8d26bfa081343f4869903e1729e1bc6f1283396d873a3c70e4273f1983353f18b084bed9f1e4bc6f1283b9f9a93d3cded328bfa18134bf516d853e1729e1bc6f1283b96d873a3c4aa1253f1a8335bf779c8fbe0f8cdabc6f128339b6a1693c64ac1ebf9c81343fa75db03e4defd6bc6f1283391ec5653cc794203f1083353f36f6a4be0f8cdabc6f1283b9b6a1693cc57921bf998134bf77e1a53e4defd6bc6f1283b91ec5653c5ecb1d3f148335bf8b63afbe780bcebc6f128339b9ac893c154415bf9b81343f3c9fce3e9ca3cabc6f1283392b66873c27b9173f1e83353f86a5c3be780bcebc6f1283b9b9ac893c859118bfa68134bf80bcc43e9ca3cabc6f1283b92b66873c6470143f128335bf3f7acdbee38ebfbc6f1283392b359d3cb36b0abfac81343f5be3ea3e5364bcbc6f128339f59b9a3c79670d3f2283353f8972e0bee38ebfbc6f1283b92b359d3c23310ebfa98134bf9db2e13e5364bcbc6f1283b9f59b9a3c67a7093f258335bf3696e9be083aafbc6f128339073aaf3c507cfcbea081343f3a72023f9454acbc6f1283399354ac3c40b9013f1683353f3e16fbbe083aafbc6f1283b9073aaf3c3e7202bf9c8134bf567cfc3e9454acbc6f1283b99354ac3c3816fb3e1a8335bf3eb901bf2d359dbc6f128339e18ebf3c9eb2e1bea881343f25310e3ff79b9abc6f1283395164bc3c3296e93e2683353f65a709bf2d359dbc6f1283b9e18ebf3c57e3eabeae8134bfb26b0a3ff79b9abc6f1283b95164bc3c8a72e03e1f8335bf7b670dbfbbac89bc6f128339760bce3c84bcc4bea781343f8591183f2d6687bc6f1283399aa3ca3c427acd3e1283353f647014bfbbac89bc6f1283b9760bce3c3d9fcebe9b8134bf1544153f2d6687bc6f1283b99aa3ca3c86a5c33e1d8335bf24b917bfbba169bc6f1283390d8cda3c79e1a5be9881343fc579213f23c565bc6f1283394befd63c8b63af3e1583353f5dcb1dbfbba169bc6f1283b90d8cda3ca95db0be9d8134bf64ac1e3f23c565bc6f1283b94befd63c37f6a43e108335bfc79420bffea93dbc6f128339d7f1e43c506d85bea081343fddd3283f72873abc6f1283391529e13c769c8f3e1983353f49a125bffea93dbc6f1283b9d7f1e43c486990bea18134bf7d8d263f72873abc6f1283b91529e13c18b0843e198335bf70e427bfa7de0fbc6f1283392d23ed3c976047be9c81343fc58d2e3fe17d0dbc6f128339c137e93c9ee65c3e1883353fe6de2bbfa7de0fbc6f1283b92d23ed3ca2215ebe9e8134bf01d42c3fe17d0dbc6f1283b9c137e93cc945463e158335bf39962dbf3a61c1bb6f128339e00bf33ce7fa01bea681343f4599323ff62ebebb6f1283397207ef3cc373183e1d83353fbe7430bf3a61c1bb6f1283b9e00bf33c354d19bea58134bf6270313ff62ebebb6f1283b97207ef3ca042013e1e8335bffa9b31bfc85042bb6f1283395c9df63c35536dbd9b81343f87ec343f8e1a3fbb6f128339d689f23c2012a53d1583353f9b5733bfc85042bb6f1283b95c9df63c6efda5bd9c8134bf5c57343f8e1a3fbb6f1283b9d689f23c67026c3d148335bff2eb33bf56c011b16f128339d6cef73c083a3e3ca681343fa681353f9a570fb16f12833942b6f33c5e2b3d3c1e83353f3e8034bf56c011b16f1283b9d6cef73c083a3ebca68134bfa681353f9a570fb16f1283b942b6f33c5e2b3dbc1e8335bf3e8034bfb650423b6f1283395c9df63c48fda53d9d81343f5d57343f7c1a3f3b6f128339d689f23c42026cbd1483353ff3eb33bfb650423b6f1283b95c9df63c0f536d3d9b8134bf88ec343f7c1a3f3b6f1283b9d689f23cf811a5bd158335bf9b5733bf3161c13b6f128339e10bf33c2a4d193ea481343f6370313fed2ebe3b6f1283397307ef3c8c4201be1e83353ffb9b31bf3161c13b6f1283b9e10bf33cd3fa013ea68134bf4699323fed2ebe3b6f1283b97307ef3cb97318be1d8335bfbf7430bfa3de0f3c6f1283392e23ed3ca2215e3e9e81343f01d42c3fdd7d0d3c6f128339c237e93cc74546be1583353f39962dbfa3de0f3c6f1283b92e23ed3c9560473e9b8134bfc58d2e3fdd7d0d3c6f1283b9c237e93c9ee65cbe198335bfe7de2bbffaa93d3c6f128339d8f1e43c4869903ea081343f7d8d263f6e873a3c6f1283391629e13c18b084be1983353f70e427bffaa93d3c6f1283b9d8f1e43c506d853ea08134bfddd3283f6e873a3c6f1283b91629e13c769c8fbe198335bf49a125bfb7a1693c6f1283390e8cda3ca95db03e9d81343f64ac1e3f1fc5653c6f1283394cefd63c37f6a4be1083353fc89420bfb7a1693c6f1283b90e8cda3c79e1a53e988134bfc579213f1fc5653c6f1283b94cefd63c8c63afbe158335bf5dcb1dbfb9ac893c6f128339770bce3c3d9fce3e9b81343f1544153f2b66873c6f1283399ba3ca3c86a5c3be1d83353f24b917bfb9ac893c6f1283b9770bce3c84bcc43ea78134bf8591183f2b66873c6f1283b99ba3ca3c427acdbe128335bf647014bf2b359d3c6f128339e28ebf3c54e3ea3eac81343fb56b0a3ff59b9a3c6f1283395264bc3c8872e0be2183353f7c670dbf2b359d3c6f1283b9e28ebf3c9ab2e13ea88134bf24310e3ff59b9a3c6f1283b95264bc3c2f96e9be268335bf69a709bf073aaf3c6f128339083aaf3c3e72023f9f81343f517cfc3e9354ac3c6f1283399454ac3c3916fbbe1983353f40b901bf073aaf3c6f1283b9083aaf3c517cfc3e9f8134bf3e72023f9354ac3c6f1283b99454ac3c40b901bf178335bf3816fbbee18ebf3c6f1283392c359d3c24310e3fa881343f99b2e13e5164bc3c6f128339f69b9a3c68a709bf2583353f2f96e9bee18ebf3c6f1283b92c359d3cb56b0a3fac8134bf54e3ea3e5164bc3c6f1283b9f69b9a3c7b670dbf218335bf8772e0be760bce3c6f128339baac893c8591183fa781343f84bcc43e9aa3ca3c6f1283392c66873c647014bf1283353f427acdbe760bce3c6f1283b9baac893c1544153f9b8134bf3d9fce3e9aa3ca3c6f1283b92c66873c24b917bf1d8335bf86a5c3be0d8cda3c6f128339b9a1693cc579213f9881343f79e1a53e4befd63c6f12833921c5653c5dcb1dbf1583353f8b63afbe0d8cda3c6f1283b9b9a1693c64ac1e3f9d8134bfa95db03e4befd63c6f1283b921c5653cc79420bf108335bf37f6a4bed7f1e43c6f128339fca93d3cded3283fa181343f516d853e1529e13c6f12833970873a3c4aa125bf1a83353f779c8fbed7f1e43c6f1283b9fca93d3c7d8d263fa18134bf4869903e1529e13c6f1283b970873a3c70e427bf198335bf18b084be2d23ed3c6f128339a5de0f3cc58d2e3f9c81343f9760473ec137e93c6f128339df7d0d3ce7de2bbf1983353f9fe65cbe2d23ed3c6f1283b9a5de0f3c01d42c3f9e8134bfa2215e3ec137e93c6f1283b9df7d0d3c38962dbf148335bfc74546bee00bf33c6f1283393661c13b4599323fa681343fe7fa013e7207ef3c6f128339f22ebe3bbe7430bf1d83353fc37318bee00bf33c6f1283b93661c13b6270313fa58134bf354d193e7207ef3c6f1283b9f22ebe3bfa9b31bf1e8335bfa04201be5c9df63c6f128339c050423b87ec343f9b81343f25546d3dd689f23c6f128339861a3f3b9a5733bf1483353f5a12a5bd5c9df63c6f1283b9c050423b5b57343f9c8134bfa9fda53dd689f23c6f1283b9861a3f3bf1eb33bf138335bf57036cbd
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 0.0000000018626451, y: 0, z: -0.0000000018626451}
+    m_Extent: {x: 0.030249998, y: 0.00025, z: 0.030249996}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshOptimized: 0
 --- !u!1 &1912893361
 GameObject:
   m_ObjectHideFlags: 0
@@ -24979,70 +40410,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1913432933
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1913432935}
-  - component: {fileID: 1913432934}
-  m_Layer: 0
-  m_Name: Pinch Gesture L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!114 &1913432934
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1913432933}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a892b794fa44ab545a989d56a2c1cd07, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  provider: {fileID: 1400439761}
-  whichHand: 0
-  drawDebugPinchDistance: 0
-  pinchActivateDistance: 0.015
-  pinchDeactivateDistance: 0.04
-  failedPinchResetDistance: 0.015
-  requireMiddleFingerAngle: 1
-  minPalmMiddleAngle: 65
-  requireRingFingerAngle: 1
-  minPalmRingAngle: 65
-  ringMiddleSafetyHysteresisMult: 0.8
-  requirePalmVsLeapAngle: 0
-  maxPalmVsLeapAngle: 181
-  maxIndexAngleForEligibilityActivation: 98
-  maxIndexAngleForEligibilityDeactivation: 110
-  maxThumbAngleForEligibilityActivation: 85
-  maxThumbAngleForEligibilityDeactivation: 100
-  OnPinchStrengthEvent:
-    m_PersistentCalls:
-      m_Calls: []
-    m_TypeName: Leap.Unity.Gestures.PinchGesture+FloatEvent, Assembly-CSharp, Version=0.0.0.0,
-      Culture=neutral, PublicKeyToken=null
-  _drawDebug: 0
-  _drawDebugPath: 0
---- !u!4 &1913432935
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1913432933}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 573826044}
-  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1914107078
 GameObject:
@@ -25296,6 +40663,82 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: 06b31ad3b87bb7b45a76168724c4eb00,
     type: 3}
   m_PrefabInternal: {fileID: 1917913021}
+--- !u!1 &1922016323
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1276499951145780, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1922016324}
+  - component: {fileID: 1922016326}
+  - component: {fileID: 1922016325}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1922016324
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4488999288851238, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1922016323}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: -0.008599946, y: 0.118264765, z: -0.049591385}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 175335083}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1922016325
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23885336914337156, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1922016323}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1922016326
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33429798537752258, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1922016323}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &1924409412
 GameObject:
   m_ObjectHideFlags: 0
@@ -25338,6 +40781,64 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _template: {fileID: 1413435390}
+--- !u!1 &1930824380
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1930824381}
+  - component: {fileID: 1930824383}
+  - component: {fileID: 1930824382}
+  m_Layer: 0
+  m_Name: Ok, we need more colors!
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1930824381
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1930824380}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1930824382
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1930824380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 532545419}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &1930824383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1930824380}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb5a8bd0b26afcd4ca1fe9a2fd717d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _director: {fileID: 1649983742}
+  _playable: {fileID: 11400000, guid: 072e18c3ad34ec74b92a37b1fee7ead8, type: 2}
+  _wrapMode: 2
 --- !u!1 &1930953163
 GameObject:
   m_ObjectHideFlags: 0
@@ -25627,6 +41128,82 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 1936582479}
+--- !u!1 &1938912148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1832871128626398, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1938912149}
+  - component: {fileID: 1938912151}
+  - component: {fileID: 1938912150}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1938912149
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4520236907858444, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1938912148}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: -0.1015221, y: 0.30100733, z: -0.21457087}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1414023800}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1938912150
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23120202040490566, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1938912148}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1938912151
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33414100102847600, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1938912148}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &1939023535
 GameObject:
   m_ObjectHideFlags: 0
@@ -25683,6 +41260,258 @@ Transform:
   m_Father: {fileID: 931763938}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1939255996
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1458848889271056, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1939255997}
+  - component: {fileID: 1939255999}
+  - component: {fileID: 1939255998}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1939255997
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4519150063542346, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1939255996}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.1479937, y: -0.0011857144, z: 0.4124145}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 817339876}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1939255998
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23073820039539248, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1939255996}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1939255999
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33537752792429778, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1939255996}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1939700507
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1079617592049454, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1939700508}
+  - component: {fileID: 1939700510}
+  - component: {fileID: 1939700509}
+  m_Layer: 5
+  m_Name: Appear Explosion Object
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1939700508
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4363197560027896, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1939700507}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1850431811}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1939700509
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23628797955712826, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1939700507}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1939700510
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33032959688782328, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1939700507}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &1941339940
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011288081652, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1941339941}
+  m_Layer: 0
+  m_Name: Middle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1941339941
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000011611320150, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1941339940}
+  m_LocalRotation: {x: -0.82590556, y: -0.016495809, z: -0.09523779, w: 0.5554617}
+  m_LocalPosition: {x: 0.23945643, y: 1.5695634, z: 1.1941721}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1201817529}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1942113992
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 159747818}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Surface
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &1942113993 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 1942113992}
 --- !u!1 &1945439766
 GameObject:
   m_ObjectHideFlags: 0
@@ -25910,6 +41739,262 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 9a6b3816b4a77fc4ca573348fc07e21a, type: 3}
   m_PrefabInternal: {fileID: 1948554419}
+--- !u!1 &1948795072
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000012113719298, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1948795073}
+  m_Layer: 0
+  m_Name: Palm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1948795073
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000011063876978, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1948795072}
+  m_LocalRotation: {x: 0.8627302, y: -0.075478025, z: -0.1294075, w: -0.48296311}
+  m_LocalPosition: {x: -0.22000602, y: 1.4704567, z: 1.2404577}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1655177877}
+  - {fileID: 487857268}
+  m_Father: {fileID: 109013843}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1955089285
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1955089286}
+  - component: {fileID: 1955089287}
+  - component: {fileID: 1955089288}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1955089286
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1955089285}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1260164693}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1955089287
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1955089285}
+--- !u!114 &1955089288
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1955089285}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 708705254, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 25
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 
+--- !u!1 &1960500061
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1575712145827056, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1960500062}
+  - component: {fileID: 1960500064}
+  - component: {fileID: 1960500063}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1960500062
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4302337642212730, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1960500061}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.14158091, y: -0.16747563, z: 0.36935246}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2079904826}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &1960500063
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23399687872865526, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1960500061}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1960500064
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33756757949469916, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1960500061}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &1962621079
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1962621080}
+  - component: {fileID: 1962621082}
+  - component: {fileID: 1962621081}
+  m_Layer: 0
+  m_Name: Now you can draw a stroke!
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1962621080
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1962621079}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1962621081
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1962621079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b580d315682b3949a58d75661dd69f2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 72011314}
+  transitionState: {fileID: 0}
+  _director: {fileID: 1649983742}
+--- !u!114 &1962621082
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1962621079}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1649983743}
+            m_MethodName: SkipMarker
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: PromptPinch
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
 --- !u!1001 &1967036827
 Prefab:
   m_ObjectHideFlags: 0
@@ -26032,7 +42117,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _displayInGameView: 1
   _enabledForBuild: 1
-  _sphereMesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 3}
+  _sphereMesh: {fileID: 4300002, guid: 2f496b1b1bec86743b418551f859020c, type: 3}
   _gizmoShader: {fileID: 4800000, guid: 309635e4933310a4d98f0e016c806769, type: 3}
 --- !u!4 &1985795327
 Transform:
@@ -26141,6 +42226,100 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: ec0802f021331cd4d96296dee2161743, type: 3}
   m_PrefabInternal: {fileID: 1994115962}
+--- !u!1 &1994642040
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1000011167817000, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1994642041}
+  - component: {fileID: 1994642044}
+  - component: {fileID: 1994642043}
+  - component: {fileID: 1994642042}
+  m_Layer: 0
+  m_Name: Index Tip Paint R
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &1994642041
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4000012513049602, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1994642040}
+  m_LocalRotation: {x: -0.99011445, y: -0.12504648, z: 0.007486235, w: -0.063093245}
+  m_LocalPosition: {x: 0, y: 0, z: 0.0014}
+  m_LocalScale: {x: -0.014959458, y: -0.014959458, z: -0.014959458}
+  m_Children: []
+  m_Father: {fileID: 45922386}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 7.235, y: -180.05399, z: 165.906}
+--- !u!114 &1994642042
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1994642040}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00f8d6ed2b677314896e1968924c49c1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _bindings:
+  - 'MeshRenderer : material._Color.r'
+  - 'MeshRenderer : material._Color.g'
+  - 'MeshRenderer : material._Color.b'
+  - 'MeshRenderer : material._Color.a'
+  _expandedTypes: []
+--- !u!23 &1994642043
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23000014225144992, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1994642040}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: b56dc6412c0c068418e3d57118a19467, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1994642044
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33000013981553338, guid: 18d6bf9063dcb1842be63f411fd9fc26,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1994642040}
+  m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &1996948495
 GameObject:
   m_ObjectHideFlags: 0
@@ -26262,6 +42441,119 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &2009537889
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1724785838045474, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2009537890}
+  - component: {fileID: 2009537892}
+  - component: {fileID: 2009537891}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2009537890
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4363414314481272, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2009537889}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.048127536, y: 0.436771, z: 0.42740968}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1743175002}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2009537891
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23961734104272502, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2009537889}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &2009537892
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33145627163113126, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2009537889}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+--- !u!1 &2010003632
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1026164510347326, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2010003633}
+  m_Layer: 0
+  m_Name: Color
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2010003633
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4201477592995148, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2010003632}
+  m_LocalRotation: {x: -0.23618016, y: -0.10529792, z: -0.06166862, w: 0.9640168}
+  m_LocalPosition: {x: 3.649703, y: -16.368929, z: 29.695711}
+  m_LocalScale: {x: 0.001, y: 0.001, z: 0.001}
+  m_Children:
+  - {fileID: 1850431811}
+  - {fileID: 1842645388}
+  - {fileID: 63207537}
+  - {fileID: 1509140293}
+  - {fileID: 1194378814}
+  - {fileID: 2113466754}
+  - {fileID: 2103416347}
+  m_Father: {fileID: 1050640148}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2016677801
 GameObject:
   m_ObjectHideFlags: 0
@@ -26462,6 +42754,256 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 2022365675}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &2022802837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2022802838}
+  - component: {fileID: 2022802840}
+  - component: {fileID: 2022802839}
+  m_Layer: 0
+  m_Name: Give me thumbs up to continue!
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2022802838
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2022802837}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 31
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2022802839
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2022802837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 715153d525c322e47890cc24adb976b3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  destination: {fileID: 1774235339}
+  transitionState: {fileID: 222778846}
+  withinAngle: 70
+  forDuration: 1
+--- !u!114 &2022802840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2022802837}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9af06f222e8680440b476670b3efaf00, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _table:
+    _entries:
+    - enumValue: 2
+      callback:
+        m_PersistentCalls:
+          m_Calls:
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: SetText
+            m_Mode: 5
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: Give me the thumbs up when you are ready to move on!
+              m_BoolArgument: 0
+            m_CallState: 2
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: UndoStroke
+            m_Mode: 1
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: 
+              m_BoolArgument: 0
+            m_CallState: 2
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: UndoStroke
+            m_Mode: 1
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: 
+              m_BoolArgument: 0
+            m_CallState: 2
+          - m_Target: {fileID: 1840705451}
+            m_MethodName: UndoStroke
+            m_Mode: 1
+            m_Arguments:
+              m_ObjectArgument: {fileID: 0}
+              m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+              m_IntArgument: 0
+              m_FloatArgument: 0
+              m_StringArgument: 
+              m_BoolArgument: 0
+            m_CallState: 2
+        m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+          Culture=neutral, PublicKeyToken=null
+--- !u!1001 &2029453416
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 505945872}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &2029453417 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 2029453416}
+--- !u!1 &2033409106
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1779154958841688, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2033409107}
+  - component: {fileID: 2033409109}
+  - component: {fileID: 2033409108}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2033409107
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4566413054957502, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2033409106}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.03540115, y: 0.14849722, z: -0.14566532}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1064702619}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2033409108
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23552828306346098, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2033409106}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &2033409109
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33558752996796002, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2033409106}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &2034229238
 GameObject:
   m_ObjectHideFlags: 0
@@ -26548,6 +43090,76 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1001 &2036328860
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1478040350}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 3300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Mesh
+      value: 
+      objectReference: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &2036328861 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 2036328860}
 --- !u!1 &2038811062
 GameObject:
   m_ObjectHideFlags: 0
@@ -26966,95 +43578,6 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2045431048}
   m_Mesh: {fileID: 4300000, guid: bb552b845e1247e4b96d83b9c9bd0207, type: 3}
---- !u!1 &2047843867
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 2047843868}
-  - component: {fileID: 2047843870}
-  - component: {fileID: 2047843869}
-  - component: {fileID: 2047843871}
-  m_Layer: 0
-  m_Name: RectToroid (Pinch State)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2047843868
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2047843867}
-  m_LocalRotation: {x: 0.000000029802322, y: 0.0000000018626451, z: -0.0000000034924597,
-    w: 1}
-  m_LocalPosition: {x: -1.3237283e-10, y: -0.000000001031506, z: 0.000000011734409}
-  m_LocalScale: {x: 1.0000002, y: 1.0000008, z: 1.0000005}
-  m_Children: []
-  m_Father: {fileID: 2085845413}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &2047843869
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2047843867}
-  m_Mesh: {fileID: 249459858}
---- !u!23 &2047843870
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2047843867}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RenderingLayerMask: 4294967295
-  m_Materials:
-  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!114 &2047843871
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2047843867}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 47976be3b9532f74496fd7dcdcd3d4b1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _radius: 0.03
-  _radialThickness: 0.00025
-  _verticalThickness: 0.00025
-  _alwaysUpdate: 0
 --- !u!1001 &2048755669
 Prefab:
   m_ObjectHideFlags: 0
@@ -27125,6 +43648,97 @@ Prefab:
 Transform:
   m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
   m_PrefabInternal: {fileID: 2048755669}
+--- !u!1 &2049983039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2049983040}
+  m_Layer: 0
+  m_Name: Brush Control Workstation Root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2049983040
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2049983039}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.24, y: 0.24, z: -4.81}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1529262421}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2052765575
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1811227958617856, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2052765576}
+  m_Layer: 0
+  m_Name: Color Swatch (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2052765576
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4753715817698050, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2052765575}
+  m_LocalRotation: {x: -2.1605053e-14, y: -0.00000007375698, z: 0.000000031610053,
+    w: 1}
+  m_LocalPosition: {x: -0.010001325, y: 0.099990845, z: 0.020003362}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 154563686}
+  - {fileID: 1201317457}
+  m_Father: {fileID: 1282821179}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2058638789
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1014926905103386, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2058638790}
+  m_Layer: 0
+  m_Name: Workstation Root
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2058638790
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4106513352704672, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2058638789}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.26, y: -0.66, z: 1.05}
+  m_LocalScale: {x: 0.40706515, y: 0.40706453, z: 0.4070645}
+  m_Children: []
+  m_Father: {fileID: 63207537}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2060420803
 GameObject:
   m_ObjectHideFlags: 0
@@ -27703,8 +44317,96 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 573826044}
-  m_RootOrder: 8
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2069969047
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2069969048}
+  - component: {fileID: 2069969051}
+  - component: {fileID: 2069969050}
+  - component: {fileID: 2069969049}
+  m_Layer: 0
+  m_Name: RectToroid (Pinch Target)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2069969048
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2069969047}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1655177877}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2069969049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2069969047}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 47976be3b9532f74496fd7dcdcd3d4b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _radius: 1
+  _radialThickness: 0.2
+  _verticalThickness: 0.02
+  _alwaysUpdate: 0
+--- !u!33 &2069969050
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2069969047}
+  m_Mesh: {fileID: 1863712964}
+--- !u!23 &2069969051
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2069969047}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 9d4796bb1fb6ce643be7d2e6e976ca62, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &2072772601
 GameObject:
   m_ObjectHideFlags: 0
@@ -27874,6 +44576,38 @@ Transform:
   m_Father: {fileID: 1931827374}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2079904825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1068811049504776, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2079904826}
+  m_Layer: 0
+  m_Name: Color Swatch (12)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2079904826
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4246337803026298, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2079904825}
+  m_LocalRotation: {x: 0.0000001263028, y: 0.7382734, z: 0.6745016, w: -0.00000013824429}
+  m_LocalPosition: {x: 0.8474312, y: 1.86, z: -0.71}
+  m_LocalScale: {x: 0.38721025, y: 0.38720945, z: 0.38720974}
+  m_Children:
+  - {fileID: 1960500062}
+  - {fileID: 1739818862}
+  m_Father: {fileID: 2113466754}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &2080287115
 Prefab:
   m_ObjectHideFlags: 0
@@ -28003,6 +44737,160 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 2080287115}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &2081700211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2081700212}
+  - component: {fileID: 2081700214}
+  - component: {fileID: 2081700213}
+  m_Layer: 0
+  m_Name: Button Icon (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2081700212
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2081700211}
+  m_LocalRotation: {x: 0, y: 0.7071068, z: -0.7071068, w: 0}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 0.1, y: 0.1, z: 0.1}
+  m_Children: []
+  m_Father: {fileID: 646267621}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 90, y: 180, z: 0}
+--- !u!102 &2081700213
+TextMesh:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2081700211}
+  m_Text: 'Rigid
+
+    Cursor'
+  m_OffsetZ: 0
+  m_CharacterSize: 1
+  m_LineSpacing: 1
+  m_Anchor: 4
+  m_Alignment: 1
+  m_TabSize: 4
+  m_FontSize: 50
+  m_FontStyle: 0
+  m_RichText: 1
+  m_Font: {fileID: 12800000, guid: cd2b86fdeb787f84698ee40d32de9350, type: 3}
+  m_Color:
+    serializedVersion: 2
+    rgba: 4287072135
+--- !u!23 &2081700214
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2081700211}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: 89e1f0dde257b3c45a5f0b5574299f85, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!1001 &2082590616
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 505945872}
+    m_Modifications:
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Name
+      value: Button Surface
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &2082590617 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: 5a046ec970a25224a81c775e7056f7ad, type: 3}
+  m_PrefabInternal: {fileID: 2082590616}
 --- !u!1 &2083882478
 GameObject:
   m_ObjectHideFlags: 0
@@ -28317,63 +45205,6 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 2084026855}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
---- !u!1 &2085845411
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 2085845413}
-  - component: {fileID: 2085845412}
-  m_Layer: 0
-  m_Name: Paint Cursor L
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &2085845412
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2085845411}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 35918ec866d8e10468441eb78c3b1cf2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  pinchMode: 0
-  pinchGesture: {fileID: 1913432934}
-  pinchDetector: {fileID: 457634426}
-  cursorFollowType: 1
-  _rectToroidPinchTarget: {fileID: 1564808034}
-  _rectToroidPinchTargetRenderer: {fileID: 1564808033}
-  _rectToroidPinchState: {fileID: 2047843871}
-  _rectToroidPinchStateRenderer: {fileID: 2047843870}
-  _indexTipColor: {fileID: 580812675}
-  capsuleHand: {fileID: 374000321}
-  _ghostableHandMat: {fileID: 2100000, guid: 92fa5c69aadc37442aecefee438af7f3, type: 2}
-  _nonGhostableHandMat: {fileID: 2100000, guid: 7eed02a120bdd6e499824de34730957d,
-    type: 2}
-  _indexTipColorRenderer: {fileID: 580812671}
-  _handModel: {fileID: 0}
---- !u!4 &2085845413
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2085845411}
-  m_LocalRotation: {x: -0.16046898, y: -0.022173751, z: 0.122600265, w: 0.9791462}
-  m_LocalPosition: {x: 0.0251, y: -0.0527, z: 0.0281}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1564808031}
-  - {fileID: 2047843868}
-  m_Father: {fileID: 1046230652}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -17.94, y: -4.8500004, z: 14.7560005}
 --- !u!1 &2094280972
 GameObject:
   m_ObjectHideFlags: 0
@@ -28477,6 +45308,82 @@ MonoBehaviour:
     _volume: 1
     _pitchVariance: 0
     _pitchCenter: 1
+--- !u!1 &2094797848
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1190841940524274, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2094797849}
+  - component: {fileID: 2094797851}
+  - component: {fileID: 2094797850}
+  m_Layer: 0
+  m_Name: Mid Layer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2094797849
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4300902842652988, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2094797848}
+  m_LocalRotation: {x: -0, y: -0, z: -6.8617886e-23, w: 1}
+  m_LocalPosition: {x: 0.19082923, y: -0.00926501, z: 0.39897618}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 30071809}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!23 &2094797850
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23316783739279214, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2094797848}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: fe23424e1b8ab5a4dba239a686477554, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &2094797851
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 33072440270878398, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2094797848}
+  m_Mesh: {fileID: 4300000, guid: 1c4fd480beb70da44bdd2093df5f2b0d, type: 3}
 --- !u!1 &2099484412
 GameObject:
   m_ObjectHideFlags: 0
@@ -28620,6 +45527,98 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
+--- !u!1 &2103416346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1673886097225312, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2103416347}
+  - component: {fileID: 2103416349}
+  - component: {fileID: 2103416348}
+  m_Layer: 0
+  m_Name: PickingTip
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2103416347
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4337887242723198, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2103416346}
+  m_LocalRotation: {x: -0, y: 0.9936703, z: 0.000000024680045, w: -0.112336025}
+  m_LocalPosition: {x: -3.78, y: -0, z: 0.18}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2010003633}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 192.9, z: 0}
+--- !u!102 &2103416348
+TextMesh:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 102450975762295488, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2103416346}
+  m_Text: 'You can poke or grab
+
+    these bubbles.'
+  m_OffsetZ: 0
+  m_CharacterSize: 0.06
+  m_LineSpacing: 1
+  m_Anchor: 4
+  m_Alignment: 0
+  m_TabSize: 4
+  m_FontSize: 100
+  m_FontStyle: 0
+  m_RichText: 1
+  m_Font: {fileID: 12800000, guid: cd2b86fdeb787f84698ee40d32de9350, type: 3}
+  m_Color:
+    serializedVersion: 2
+    rgba: 4291809231
+--- !u!23 &2103416349
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 23182179090794462, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2103416346}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 2100000, guid: cc286002d68242848ba787b98f9f35b3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
 --- !u!1 &2105069581
 GameObject:
   m_ObjectHideFlags: 0
@@ -28679,6 +45678,11 @@ Prefab:
         type: 2}
       propertyPath: soundEffect._clips.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.size
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4000013939052844, guid: c915520bed265f24c95aebc38ee51557, type: 2}
       propertyPath: m_LocalPosition.x
@@ -28774,6 +45778,31 @@ Prefab:
       value: 
       objectReference: {fileID: 243000011340830754, guid: 43de2443e9a4ff54e842fdf9d3168906,
         type: 2}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1840705451}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: NotifyColorPalleteTouched
+      objectReference: {fileID: 0}
+    - target: {fileID: 114000014244550774, guid: c915520bed265f24c95aebc38ee51557,
+        type: 2}
+      propertyPath: OnPress.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c915520bed265f24c95aebc38ee51557, type: 2}
   m_IsPrefabParent: 0
@@ -28793,6 +45822,93 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 2105377231}
   m_Script: {fileID: 11500000, guid: db3a2de512801714fac0bb60f90b74db, type: 3}
+--- !u!1 &2108548014
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1718003457852036, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2108548015}
+  m_Layer: 0
+  m_Name: Marble Depth Touch Collider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2108548015
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4817676899655422, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2108548014}
+  m_LocalRotation: {x: 0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0, z: -1.144}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1842645388}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2113466753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 1593289656251720, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2113466754}
+  m_Layer: 5
+  m_Name: Secondary Palette
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2113466754
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 4024615063091136, guid: a8bc4fec6933c504c9a428e60aca9c7d,
+    type: 2}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2113466753}
+  m_LocalRotation: {x: -0.05593642, y: -0, z: -0, w: 0.99843436}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.00999999, y: 0.00999999, z: 0.00999999}
+  m_Children:
+  - {fileID: 866310163}
+  - {fileID: 1064702619}
+  - {fileID: 817339876}
+  - {fileID: 1341977917}
+  - {fileID: 990536909}
+  - {fileID: 1172146390}
+  - {fileID: 552670153}
+  - {fileID: 66919111}
+  - {fileID: 30071809}
+  - {fileID: 266988905}
+  - {fileID: 158968539}
+  - {fileID: 1851737852}
+  - {fileID: 872341593}
+  - {fileID: 2079904826}
+  - {fileID: 175335083}
+  - {fileID: 1455914325}
+  - {fileID: 790923305}
+  - {fileID: 1094083028}
+  - {fileID: 1171800794}
+  - {fileID: 504093782}
+  - {fileID: 1743175002}
+  - {fileID: 1513574475}
+  - {fileID: 480798553}
+  - {fileID: 752051449}
+  - {fileID: 857226719}
+  - {fileID: 1101815129}
+  - {fileID: 1445655200}
+  m_Father: {fileID: 2010003633}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: -6.3650002, y: 0, z: 0}
 --- !u!1 &2113609786
 GameObject:
   m_ObjectHideFlags: 0
@@ -28970,6 +46086,72 @@ MeshRenderer:
   m_PrefabParentObject: {fileID: 2300000, guid: 5a046ec970a25224a81c775e7056f7ad,
     type: 3}
   m_PrefabInternal: {fileID: 2129175159}
+--- !u!1001 &2130400785
+Prefab:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1159817118}
+    m_Modifications:
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.00001001358
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.0000005811452
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.00000029127108
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.000000052154054
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 100000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_Name
+      value: Slider Back
+      objectReference: {fileID: 0}
+    - target: {fileID: 2300000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: c855668d629c08044928cf661d97e75b, type: 2}
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 100100000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+  m_IsPrefabParent: 0
+--- !u!4 &2130400786 stripped
+Transform:
+  m_PrefabParentObject: {fileID: 400000, guid: b1b89b12b8c3ec849bfd21071bc9049e, type: 3}
+  m_PrefabInternal: {fileID: 2130400785}
 --- !u!1 &2131341852
 GameObject:
   m_ObjectHideFlags: 0
@@ -29042,6 +46224,34 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2131341852}
   m_Mesh: {fileID: 10208, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2135389033
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2135389034}
+  m_Layer: 0
+  m_Name: '--------'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2135389034
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2135389033}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1840705453}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2137139289
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapPaint (v3)/Tutorial/TutorialControl.cs
+++ b/Assets/LeapPaint (v3)/Tutorial/TutorialControl.cs
@@ -9,7 +9,7 @@ using Leap.Unity.LeapPaint_v3;
 public class TutorialControl : MonoBehaviour {
 
   public Text text;
-  public PinchGesture leftPinch, rightPinch;
+  public PinchGesture rightPinch;
   public Transform strokeParent;
   public Widget colorWidget;
   public Widget brushWidget;
@@ -29,6 +29,32 @@ public class TutorialControl : MonoBehaviour {
     }
   }
 
+  public void EnableTutorial() {
+    // Set the player rig state to reflect what the beginning of the tutorial expects.
+    rightPinch.enabled = false;
+
+    StartCoroutine(colorWidget.Disable());
+    StartCoroutine(brushWidget.Disable());
+    StartCoroutine(menuWidget.Disable());
+
+    //if (bigColorEmergable != null) {
+    //  bigColorEmergable.TryVanishNow(isInWorkstation: true);
+    //}
+
+    brushThicknessObject.SetActive(false);
+  }
+
+  public void DisableTutorial() {
+    // Unlock everything!
+    rightPinch.enabled = true;
+
+    StartCoroutine(colorWidget.Enable());
+    StartCoroutine(brushWidget.Enable());
+    StartCoroutine(menuWidget.Enable());
+
+    brushThicknessObject.SetActive(true);
+  }
+
   public void SetText(string text) {
     this.text.text = text;
   }
@@ -38,7 +64,6 @@ public class TutorialControl : MonoBehaviour {
   }
 
   public void EnablePinching() {
-    leftPinch.enabled = true;
     rightPinch.enabled = true;
   }
 
@@ -65,7 +90,7 @@ public class TutorialControl : MonoBehaviour {
   }
 
   public void EnableFinalMenu() {
-    menuWidget.Enable();
+    StartCoroutine(menuWidget.Enable());
   }
 
   public void NotifyColorPalleteTouched() {
@@ -89,23 +114,38 @@ public class TutorialControl : MonoBehaviour {
   public struct Widget {
     public GameObject widget;
     public GameObject ring;
-    public EmergeableBehaviour emergable;
+    public EmergeableBehaviour[] emergables;
     public InteractionBehaviour ieBehaviour;
     public IndexUIActivator_PassTriggerEvents trigger;
 
     public IEnumerator Enable() {
       ring.SetActive(true);
 
-
-
       widget.GetComponent<WearableUI>().forceHide = false;
       widget.GetComponent<WearableUI>().RefreshVisibility();
 
-      if (emergable != null) {
-        emergable.TryEmerge(isInWorkstation: true);
+      foreach (var emergable in emergables) {
+        if (emergable != null) {
+          emergable.TryEmerge(isInWorkstation: false);
+        }
       }
 
       yield return null;
+    }
+
+    public IEnumerator Disable() {
+      yield return new WaitForEndOfFrame();
+
+      foreach (var emergable in emergables) {
+        if (emergable != null) {
+          emergable.TryVanish(isInWorkstation: false);
+        }
+      }
+
+      widget.GetComponent<WearableUI>().forceHide = true;
+      widget.GetComponent<WearableUI>().RefreshVisibility();
+
+      ring.SetActive(false);
     }
   }
 }

--- a/Assets/LeapPaint (v3)/Tutorial/TutorialEnableDisableOnAwake.cs
+++ b/Assets/LeapPaint (v3)/Tutorial/TutorialEnableDisableOnAwake.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using UnityEngine;
+
+namespace Leap.Unity.LeapPaint_v3 {
+
+  public class TutorialEnableDisableOnAwake : MonoBehaviour {
+
+    public TutorialControl tutorialControl;
+
+    [Header("Enabled State on Awake (overridden by flags)")]
+    public bool tutorialEnabledOnAwake = true;
+    public string enableTutorialFlag = "--enable-tutorial";
+    public string disableTutorialFlag = "--disable-tutorial";
+
+    private bool _shouldTutorialBeEnabled = true;
+
+    private void Awake() {
+      _shouldTutorialBeEnabled = tutorialEnabledOnAwake;
+
+      string[] arguments = Environment.GetCommandLineArgs();
+      for (int i = 0; i < arguments.Length; i++) {
+        if (arguments.Equals(enableTutorialFlag)) {
+          _shouldTutorialBeEnabled = true;
+        }
+        if (arguments.Equals(disableTutorialFlag)) {
+          _shouldTutorialBeEnabled = false;
+        }
+      }
+
+      if (tutorialControl != null) {
+        if (_shouldTutorialBeEnabled) {
+          tutorialControl.EnableTutorial();
+        }
+        else {
+          tutorialControl.DisableTutorial();
+        }
+      }
+    }
+
+  }
+
+}

--- a/Assets/LeapPaint (v3)/Tutorial/TutorialEnableDisableOnAwake.cs.meta
+++ b/Assets/LeapPaint (v3)/Tutorial/TutorialEnableDisableOnAwake.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79167bbb9c3284a4a95d143f93afa081
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Merges the tutorial into the main scene and adds the ability to skip the tutorial.

It does add public EnableTutorial and DisableTutorial methods, although I haven't tested doing that at runtime (other than on Awake()).

This _is_ missing functionality where disabling the tutorial on Awake() also actually disables Mr. Tutorial Man.